### PR TITLE
Update `remote-state` module

### DIFF
--- a/modules/remote-state/main.tf
+++ b/modules/remote-state/main.tf
@@ -1,8 +1,7 @@
-module "backend" {
+module "backend_config" {
   source         = "../backend"
   config         = var.config
   component_type = var.component_type
-  component      = var.component
 }
 
 module "vars" {
@@ -13,8 +12,8 @@ module "vars" {
 }
 
 locals {
-  backend_type = module.backend.backend_type
-  backend      = module.backend.backend
+  backend_type = module.backend_config.backend_type
+  backend      = module.backend_config.backend
   vars         = module.vars.vars
 
   environment = coalesce(module.this.environment, local.vars.environment)

--- a/modules/remote-state/s3.tf
+++ b/modules/remote-state/s3.tf
@@ -10,7 +10,7 @@ data "terraform_remote_state" "s3" {
     bucket               = local.backend.bucket
     key                  = local.backend.key
     dynamodb_table       = local.backend.dynamodb_table
-    region               = local.vars.region
+    region               = local.backend.region
     role_arn             = var.privileged ? null : local.backend.role_arn
     workspace_key_prefix = var.component
   }


### PR DESCRIPTION
## what
* Update `remote-state` module

## why
* Use the region defined in the backend config (not in general stack config)
* For `remote-state` module, no need to provide the component since we specify `workspace_key_prefix` via `var.component`


