### PR TITLE
Default include_component_in_workspace_name to false

### DIFF
--- a/modules/remote-state/main.tf
+++ b/modules/remote-state/main.tf
@@ -8,14 +8,6 @@ locals {
   backend_type = module.backend_config.backend_type
   backend      = module.backend_config.backend
 
-  workspace_from_environment_stage = var.include_component_in_workspace_name ? format("%s-%s-%s", module.this.environment, module.this.stage, var.component) : (
-    format("%s-%s", module.this.environment, module.this.stage)
-  )
-
-  workspace = var.workspace != null ? var.workspace : (
-    try(local.backend.workspace, null) != null ? local.backend.workspace : local.workspace_from_environment_stage
-  )
-
   remote_states = {
     s3     = data.terraform_remote_state.s3
     remote = data.terraform_remote_state.remote

--- a/modules/remote-state/remote.tf
+++ b/modules/remote-state/remote.tf
@@ -1,3 +1,11 @@
+locals {
+  remote_workspace_from_environment_stage = format("%s-%s-%s", module.this.environment, module.this.stage, var.component)
+
+  remote_workspace = var.workspace != null ? var.workspace : (
+    try(local.backend.workspace, null) != null ? local.backend.workspace : local.remote_workspace_from_environment_stage
+  )
+}
+
 data "terraform_remote_state" "remote" {
   count = local.backend_type == "remote" ? 1 : 0
 
@@ -7,7 +15,7 @@ data "terraform_remote_state" "remote" {
     organization = local.backend.organization
 
     workspaces = {
-      name = local.workspace
+      name = local.remote_workspace
     }
   }
 

--- a/modules/remote-state/s3.tf
+++ b/modules/remote-state/s3.tf
@@ -1,9 +1,19 @@
+locals {
+  s3_workspace_from_environment_stage = var.include_component_in_workspace_name ? format("%s-%s-%s", module.this.environment, module.this.stage, var.component) : (
+    format("%s-%s", module.this.environment, module.this.stage)
+  )
+
+  s3_workspace = var.workspace != null ? var.workspace : (
+    try(local.backend.workspace, null) != null ? local.backend.workspace : local.s3_workspace_from_environment_stage
+  )
+}
+
 data "terraform_remote_state" "s3" {
   count = local.backend_type == "s3" ? 1 : 0
 
   backend = "s3"
 
-  workspace = local.workspace
+  workspace = local.s3_workspace
 
   config = {
     encrypt              = local.backend.encrypt

--- a/modules/remote-state/variables.tf
+++ b/modules/remote-state/variables.tf
@@ -35,5 +35,5 @@ variable "workspace" {
 variable "include_component_in_workspace_name" {
   type        = bool
   description = "Whether to include the component name in the workspace name"
-  default     = true
+  default     = false
 }


### PR DESCRIPTION
## what
- Change `include_component_in_workspace_name` default to `false`

## why
- All current clients need `include_component_in_workspace_name` set to false for s3 backend
- By the time anyone needs this set to `true`, there will be a different mechanism (stack config itself) for setting it to false