### PR TITLE
Use `component` attribute. Bump `terraform-provider-utils` version

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,13 +297,13 @@ Available targets:
 | external | >= 2.0 |
 | local | >= 1.3 |
 | template | >= 2.2 |
-| utils | >= 0.2.0 |
+| utils | >= 0.2.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| utils | >= 0.2.0 |
+| utils | >= 0.2.1 |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -7,13 +7,13 @@
 | external | >= 2.0 |
 | local | >= 1.3 |
 | template | >= 2.2 |
-| utils | >= 0.2.0 |
+| utils | >= 0.2.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| utils | >= 0.2.0 |
+| utils | >= 0.2.1 |
 
 ## Inputs
 

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -12,3 +12,8 @@ output "backend" {
   value       = module.backend.backend
   description = "Backend configuration for the component"
 }
+
+output "base_component" {
+  value       = module.backend.base_component
+  description = "Base component name"
+}

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.2.0"
+      version = ">= 0.2.1"
     }
   }
 }

--- a/examples/remote-state/main.tf
+++ b/examples/remote-state/main.tf
@@ -4,6 +4,8 @@ module "remote_state_my_vpc" {
   stack_config_local_path = var.stack_config_local_path
   stack                   = var.stack
   component               = "my-vpc"
+
+  context = module.this.context
 }
 
 module "remote_state_eks" {
@@ -12,4 +14,6 @@ module "remote_state_eks" {
   stack_config_local_path = var.stack_config_local_path
   stack                   = var.stack
   component               = "eks"
+
+  context = module.this.context
 }

--- a/examples/remote-state/outputs.tf
+++ b/examples/remote-state/outputs.tf
@@ -3,7 +3,27 @@ output "my_vpc_outputs" {
   description = "Remote state outputs of the `my-vpc` component"
 }
 
+output "my_vpc_base_component" {
+  value       = module.remote_state_my_vpc.base_component
+  description = "Base component of `my-vpc` component"
+}
+
+output "my_vpc_terraform_workspace" {
+  value       = module.remote_state_my_vpc.s3_workspace_name
+  description = "Terraform workspace name for the `my-vpc` component s3 backend"
+}
+
 output "eks_outputs" {
   value       = module.remote_state_eks.outputs
   description = "Remote state outputs of the `eks` component"
+}
+
+output "eks_base_component" {
+  value       = module.remote_state_eks.base_component
+  description = "Base component of `eks` component"
+}
+
+output "eks_terraform_workspace" {
+  value       = module.remote_state_eks.s3_workspace_name
+  description = "Terraform workspace name for the `eks` component s3 backend"
 }

--- a/examples/remote-state/stacks/my-stack.yaml
+++ b/examples/remote-state/stacks/my-stack.yaml
@@ -16,6 +16,7 @@ components:
       component: vpc
       vars:
         cidr_block: "10.132.0.0/18"
+        test: false
     vpc:
       vars:
         cidr_block: "10.102.0.0/18"

--- a/examples/remote-state/versions.tf
+++ b/examples/remote-state/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.2.0"
+      version = ">= 0.2.1"
     }
   }
 }

--- a/examples/stacks/versions.tf
+++ b/examples/stacks/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.2.0"
+      version = ">= 0.2.1"
     }
   }
 }

--- a/modules/backend/main.tf
+++ b/modules/backend/main.tf
@@ -9,5 +9,5 @@ data "utils_stack_config_yaml" "config" {
 locals {
   backend_type   = yamldecode(data.utils_stack_config_yaml.config.output[0])["components"][var.component_type][var.component]["backend_type"]
   backend        = yamldecode(data.utils_stack_config_yaml.config.output[0])["components"][var.component_type][var.component]["backend"]
-  base_component = try(yamldecode(data.utils_stack_config_yaml.config.output[0])["components"][var.component_type][var.component]["component"], null)
+  base_component = try(yamldecode(data.utils_stack_config_yaml.config.output[0])["components"][var.component_type][var.component]["component"], "")
 }

--- a/modules/backend/main.tf
+++ b/modules/backend/main.tf
@@ -7,6 +7,7 @@ data "utils_stack_config_yaml" "config" {
 }
 
 locals {
-  backend_type = yamldecode(data.utils_stack_config_yaml.config.output[0])["components"][var.component_type][var.component]["backend_type"]
-  backend      = yamldecode(data.utils_stack_config_yaml.config.output[0])["components"][var.component_type][var.component]["backend"]
+  backend_type   = yamldecode(data.utils_stack_config_yaml.config.output[0])["components"][var.component_type][var.component]["backend_type"]
+  backend        = yamldecode(data.utils_stack_config_yaml.config.output[0])["components"][var.component_type][var.component]["backend"]
+  base_component = try(yamldecode(data.utils_stack_config_yaml.config.output[0])["components"][var.component_type][var.component]["component"], null)
 }

--- a/modules/backend/outputs.tf
+++ b/modules/backend/outputs.tf
@@ -7,3 +7,8 @@ output "backend" {
   value       = local.backend
   description = "Backend configuration for the component"
 }
+
+output "base_component" {
+  value       = local.base_component
+  description = "Base component name"
+}

--- a/modules/backend/versions.tf
+++ b/modules/backend/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.2.0"
+      version = ">= 0.2.1"
     }
   }
 }

--- a/modules/remote-state/README.md
+++ b/modules/remote-state/README.md
@@ -13,7 +13,7 @@ __NOTE:__ The backend type (`s3`) and backend configuration for the components a
 
   ```hcl
     module "remote_state_my_vpc" {
-      source = "cloudposse/stack-config/yaml"
+      source = "cloudposse/stack-config/yaml//modules/remote-state"
       # Cloud Posse recommends pinning every module to a specific version
       # version     = "x.x.x"
     
@@ -23,7 +23,7 @@ __NOTE:__ The backend type (`s3`) and backend configuration for the components a
     }
     
     module "remote_state_eks" {
-      source = "cloudposse/stack-config/yaml"
+      source = "cloudposse/stack-config/yaml//modules/remote-state"
       # Cloud Posse recommends pinning every module to a specific version
       # version     = "x.x.x"
     

--- a/modules/remote-state/main.tf
+++ b/modules/remote-state/main.tf
@@ -10,8 +10,9 @@ module "backend_config" {
 }
 
 locals {
-  backend_type = module.backend_config.backend_type
-  backend      = module.backend_config.backend
+  backend_type   = module.backend_config.backend_type
+  backend        = module.backend_config.backend
+  base_component = module.backend_config.base_component
 
   remote_states = {
     s3     = data.terraform_remote_state.s3

--- a/modules/remote-state/main.tf
+++ b/modules/remote-state/main.tf
@@ -10,6 +10,8 @@ module "backend_config" {
 }
 
 locals {
+  stack = var.stack != null ? var.stack : format("%s-%s", module.this.environment, module.this.stage)
+
   backend_type   = module.backend_config.backend_type
   backend        = module.backend_config.backend
   base_component = module.backend_config.base_component

--- a/modules/remote-state/outputs.tf
+++ b/modules/remote-state/outputs.tf
@@ -13,6 +13,16 @@ output "base_component" {
   description = "Base component name"
 }
 
+output "s3_workspace_name" {
+  value       = local.s3_workspace
+  description = "Terraform workspace name for the component s3 backend"
+}
+
+output "remote_workspace_name" {
+  value       = local.remote_workspace
+  description = "Terraform workspace name for the component remote backend"
+}
+
 output "outputs" {
   value       = local.outputs
   description = "The outputs of the component"

--- a/modules/remote-state/outputs.tf
+++ b/modules/remote-state/outputs.tf
@@ -8,6 +8,11 @@ output "backend" {
   description = "Backend configuration for the component"
 }
 
+output "base_component" {
+  value       = local.base_component
+  description = "Base component name"
+}
+
 output "outputs" {
   value       = local.outputs
   description = "The outputs of the component"

--- a/modules/remote-state/remote.tf
+++ b/modules/remote-state/remote.tf
@@ -1,6 +1,4 @@
 locals {
-  stack = var.stack != null ? var.stack : format("%s-%s", module.this.environment, module.this.stage)
-
   remote_workspace_from_stack = format("%s-%s", local.stack, var.component)
 
   remote_workspace = var.workspace != null ? var.workspace : (

--- a/modules/remote-state/remote.tf
+++ b/modules/remote-state/remote.tf
@@ -1,8 +1,10 @@
 locals {
-  remote_workspace_from_environment_stage = format("%s-%s-%s", module.this.environment, module.this.stage, var.component)
+  stack = var.stack != null ? var.stack : format("%s-%s", module.this.environment, module.this.stage)
+
+  remote_workspace_from_stack = format("%s-%s", local.stack, var.component)
 
   remote_workspace = var.workspace != null ? var.workspace : (
-    try(local.backend.workspace, null) != null ? local.backend.workspace : local.remote_workspace_from_environment_stage
+    try(local.backend.workspace, null) != null ? local.backend.workspace : local.remote_workspace_from_stack
   )
 }
 

--- a/modules/remote-state/s3.tf
+++ b/modules/remote-state/s3.tf
@@ -1,5 +1,5 @@
 locals {
-  include_component_in_workspace_name = var.include_component_in_workspace_name == true || local.base_component != null || local.base_component != ""
+  include_component_in_workspace_name = var.include_component_in_workspace_name == true || local.base_component != ""
 
   s3_workspace_from_stack = local.include_component_in_workspace_name ? format("%s-%s", local.stack, var.component) : local.stack
 

--- a/modules/remote-state/s3.tf
+++ b/modules/remote-state/s3.tf
@@ -1,8 +1,6 @@
 locals {
   include_component_in_workspace_name = var.include_component_in_workspace_name == true || local.base_component != null || local.base_component != ""
 
-  stack = var.stack != null ? var.stack : format("%s-%s", module.this.environment, module.this.stage)
-
   s3_workspace_from_stack = local.include_component_in_workspace_name ? format("%s-%s", local.stack, var.component) : local.stack
 
   s3_workspace = var.workspace != null ? var.workspace : (

--- a/modules/remote-state/s3.tf
+++ b/modules/remote-state/s3.tf
@@ -1,5 +1,7 @@
 locals {
-  s3_workspace_from_environment_stage = var.include_component_in_workspace_name ? format("%s-%s-%s", module.this.environment, module.this.stage, var.component) : (
+  include_component_in_workspace_name = var.include_component_in_workspace_name == true || local.base_component != null
+
+  s3_workspace_from_environment_stage = local.include_component_in_workspace_name ? format("%s-%s-%s", module.this.environment, module.this.stage, var.component) : (
     format("%s-%s", module.this.environment, module.this.stage)
   )
 

--- a/modules/remote-state/s3.tf
+++ b/modules/remote-state/s3.tf
@@ -1,12 +1,12 @@
 locals {
-  include_component_in_workspace_name = var.include_component_in_workspace_name == true || local.base_component != null
+  include_component_in_workspace_name = var.include_component_in_workspace_name == true || local.base_component != null || local.base_component != ""
 
-  s3_workspace_from_environment_stage = local.include_component_in_workspace_name ? format("%s-%s-%s", module.this.environment, module.this.stage, var.component) : (
-    format("%s-%s", module.this.environment, module.this.stage)
-  )
+  stack = var.stack != null ? var.stack : format("%s-%s", module.this.environment, module.this.stage)
+
+  s3_workspace_from_stack = local.include_component_in_workspace_name ? format("%s-%s", local.stack, var.component) : local.stack
 
   s3_workspace = var.workspace != null ? var.workspace : (
-    try(local.backend.workspace, null) != null ? local.backend.workspace : local.s3_workspace_from_environment_stage
+    try(local.backend.workspace, null) != null ? local.backend.workspace : local.s3_workspace_from_stack
   )
 }
 

--- a/modules/remote-state/variables.tf
+++ b/modules/remote-state/variables.tf
@@ -41,6 +41,6 @@ variable "workspace" {
 
 variable "include_component_in_workspace_name" {
   type        = bool
-  description = "Whether to include the component name in the workspace name"
+  description = "Whether to include the component name in the workspace name. This variable, if set, overrides the `component` attribute in YAML stack configs"
   default     = false
 }

--- a/modules/remote-state/variables.tf
+++ b/modules/remote-state/variables.tf
@@ -35,7 +35,7 @@ variable "defaults" {
 
 variable "workspace" {
   type        = string
-  description = "Workspace"
+  description = "Workspace (this overrides the workspace calculated from `var.stack`, `var.environment` and `var.stage`)"
   default     = null
 }
 

--- a/modules/remote-state/versions.tf
+++ b/modules/remote-state/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.2.0"
+      version = ">= 0.2.1"
     }
   }
 }

--- a/modules/vars/versions.tf
+++ b/modules/vars/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.2.0"
+      version = ">= 0.2.1"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.2.0"
+      version = ">= 0.2.1"
     }
   }
 }


### PR DESCRIPTION
## what
* Use `component` attribute in the workspaces of Terraform components that inherit from a base component
* Bump `terraform-provider-utils` version

## why
* The `component` attribute is used in remote backends to decide whether or not to add the component name to the Terraform workspace name

## references
* https://github.com/cloudposse/terraform-provider-utils/pull/16
