### PR TITLE
Add `workspace` to terraform outputs

### DIFF
--- a/examples/stacks/README.md
+++ b/examples/stacks/README.md
@@ -123,6 +123,7 @@ The module returns `vars` and `backend` configurations for all Terraform and hel
                 "region" = "us-west-2"
                 "stage" = "dev"
               }
+              "workspace" = "uw2-dev"
             }
             "aurora-postgres" = {
               "backend" = {
@@ -160,6 +161,7 @@ The module returns `vars` and `backend` configurations for all Terraform and hel
                 "region" = "us-west-2"
                 "stage" = "dev"
               }
+              "workspace" = "uw2-dev"
             }
             "aurora-postgres-2" = {
               "backend" = {
@@ -201,6 +203,7 @@ The module returns `vars` and `backend` configurations for all Terraform and hel
                 "region" = "us-west-2"
                 "stage" = "dev"
               }
+              "workspace" = "uw2-dev-aurora-postgres-2"
             }
             "vpc" = {
               "backend" = {
@@ -245,6 +248,7 @@ The module returns `vars` and `backend` configurations for all Terraform and hel
                 "vpc_flow_logs_enabled" = true
                 "vpc_flow_logs_traffic_type" = "ALL"
               }
+              "workspace" = "uw2-dev"
             }
             "eks" = {
               "backend" = {
@@ -299,6 +303,7 @@ The module returns `vars` and `backend` configurations for all Terraform and hel
                 }
                 "stage" = "dev"
               }
+              "workspace" = "uw2-dev"
             }
           }
         }

--- a/main.tf
+++ b/main.tf
@@ -3,5 +3,28 @@ data "utils_stack_config_yaml" "config" {
 }
 
 locals {
-  config = [for i in data.utils_stack_config_yaml.config.output : yamldecode(i)]
+  decoded = [for i in data.utils_stack_config_yaml.config.output : yamldecode(i)]
+
+  config = [
+    for stack in local.decoded : {
+      components = {
+        helmfile = stack.components.helmfile,
+        terraform = {
+          for k, v in stack.components.terraform : k => {
+            backend      = v.backend
+            backend_type = v.backend_type
+            env          = v.env
+            settings     = v.settings,
+            vars         = v.vars
+            component    = try(v.component, null)
+            workspace = try(v.backend_type, "") == "remote" ? format("%s-%s", format("%s-%s", try(v.vars.environment, ""), try(v.vars.stage, "")), k) : (
+              try(v.component, null) != null ? format("%s-%s-%s", try(v.vars.environment, ""), try(v.vars.stage, ""), k) : (
+                format("%s-%s", try(v.vars.environment, ""), try(v.vars.stage, ""))
+              )
+            )
+          }
+        }
+      }
+    }
+  ]
 }

--- a/modules/remote-state/remote.tf
+++ b/modules/remote-state/remote.tf
@@ -1,9 +1,5 @@
 locals {
-  remote_workspace_from_stack = format("%s-%s", local.stack, var.component)
-
-  remote_workspace = var.workspace != null ? var.workspace : (
-    try(local.backend.workspace, null) != null ? local.backend.workspace : local.remote_workspace_from_stack
-  )
+  remote_workspace = var.workspace != null ? var.workspace : format("%s-%s", local.stack, var.component)
 }
 
 data "terraform_remote_state" "remote" {

--- a/modules/remote-state/s3.tf
+++ b/modules/remote-state/s3.tf
@@ -3,9 +3,7 @@ locals {
 
   s3_workspace_from_stack = local.include_component_in_workspace_name ? format("%s-%s", local.stack, var.component) : local.stack
 
-  s3_workspace = var.workspace != null ? var.workspace : (
-    try(local.backend.workspace, null) != null ? local.backend.workspace : local.s3_workspace_from_stack
-  )
+  s3_workspace = var.workspace != null ? var.workspace : local.s3_workspace_from_stack
 }
 
 data "terraform_remote_state" "s3" {

--- a/test/src/Makefile
+++ b/test/src/Makefile
@@ -16,7 +16,8 @@ init:
 ## Run tests
 test: init
 	go mod download
-	go test -v -timeout 60m -run TestExamplesComplete
+	go test -v -timeout 5m -run TestExamplesComplete
+	go test -v -timeout 5m -run TestExamplesStacks
 
 ## Run tests in docker container
 docker/test:

--- a/test/src/examples_stacks_test.go
+++ b/test/src/examples_stacks_test.go
@@ -1,0 +1,41 @@
+package test
+
+import (
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// Test the Terraform module in examples/complete using Terratest.
+func TestExamplesStacks(t *testing.T) {
+	t.Parallel()
+
+	terraformOptions := &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: "../../examples/stacks",
+		Upgrade:      true,
+		// Variables to pass to our Terraform code using -var-file options
+		VarFiles: []string{"fixtures.tfvars"},
+	}
+
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created
+	defer terraform.Destroy(t, terraformOptions)
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Run `terraform output` to get the value of an output variable
+	config := terraform.OutputListOfObjects(t, terraformOptions, "config")
+	// Verify we're getting back the outputs we expect
+	assert.Greater(t, len(config), 4)
+
+	uatConfig := config[3]
+	uatComponents := uatConfig["components"].(map[interface{}]interface{})
+	uatTerraformComponents := uatComponents["terraform"].(map[interface{}]interface{})
+	auroraPostgresComponent := uatTerraformComponents["aurora-postgres"].(map[interface{}]interface{})
+	auroraPostgres2Component := uatTerraformComponents["aurora-postgres-2"].(map[interface{}]interface{})
+	auroraPostgresWorkspace := auroraPostgresComponent["workspace"]
+	auroraPostgres2Workspace := auroraPostgres2Component["workspace"]
+	assert.Equal(t, "uw2-uat", auroraPostgresWorkspace)
+	assert.Equal(t, "uw2-uat-aurora-postgres-2", auroraPostgres2Workspace)
+}

--- a/test/src/examples_stacks_test.go
+++ b/test/src/examples_stacks_test.go
@@ -25,11 +25,13 @@ func TestExamplesStacks(t *testing.T) {
 	terraform.InitAndApply(t, terraformOptions)
 
 	// Run `terraform output` to get the value of an output variable
-	config := terraform.OutputListOfObjects(t, terraformOptions, "config")
-	// Verify we're getting back the outputs we expect
-	assert.Greater(t, len(config), 4)
+	var output interface{}
+	terraform.OutputStruct(t, terraformOptions, "config", &output)
+	config := output.([]interface{})
 
-	uatConfig := config[3]
+	// Verify we're getting back the outputs we expect
+	assert.Equal(t, len(config), 4)
+	uatConfig := config[3].(map[string]interface{})
 	uatComponents := uatConfig["components"].(map[string]interface{})
 	uatTerraformComponents := uatComponents["terraform"].(map[string]interface{})
 	auroraPostgresComponent := uatTerraformComponents["aurora-postgres"].(map[string]interface{})

--- a/test/src/examples_stacks_test.go
+++ b/test/src/examples_stacks_test.go
@@ -30,10 +30,10 @@ func TestExamplesStacks(t *testing.T) {
 	assert.Greater(t, len(config), 4)
 
 	uatConfig := config[3]
-	uatComponents := uatConfig["components"].(map[interface{}]interface{})
-	uatTerraformComponents := uatComponents["terraform"].(map[interface{}]interface{})
-	auroraPostgresComponent := uatTerraformComponents["aurora-postgres"].(map[interface{}]interface{})
-	auroraPostgres2Component := uatTerraformComponents["aurora-postgres-2"].(map[interface{}]interface{})
+	uatComponents := uatConfig["components"].(map[string]interface{})
+	uatTerraformComponents := uatComponents["terraform"].(map[string]interface{})
+	auroraPostgresComponent := uatTerraformComponents["aurora-postgres"].(map[string]interface{})
+	auroraPostgres2Component := uatTerraformComponents["aurora-postgres-2"].(map[string]interface{})
 	auroraPostgresWorkspace := auroraPostgresComponent["workspace"]
 	auroraPostgres2Workspace := auroraPostgres2Component["workspace"]
 	assert.Equal(t, "uw2-uat", auroraPostgresWorkspace)


### PR DESCRIPTION
## what
* Add `workspace` to terraform outputs

## why
* Calculate Terraform workspace for all Terraform components taking into account the base component using the `component` attribute
* Simplify calling modules

```
       "aurora-postgres" = {
          "backend" = {
            "acl" = "bucket-owner-full-control"
            "bucket" = "eg-uw2-root-tfstate"
            "dynamodb_table" = "eg-uw2-root-tfstate-lock"
            "encrypt" = true
            "key" = "terraform.tfstate"
            "region" = "us-west-2"
            "role_arn" = "arn:aws:iam::XXXXXXXXXXXX:role/eg-gbl-root-terraform"
            "workspace_key_prefix" = "aurora-postgres"
          }
          "backend_type" = "s3"
          "component" = null
          "env" = {
            "ENV_TEST_1" = "test1"
            "ENV_TEST_2" = "test2"
            "ENV_TEST_3" = "test3"
            "ENV_TEST_4" = "test4"
            "ENV_TEST_5" = "test5"
            "ENV_TEST_6" = "test6"
            "ENV_TEST_7" = "test7"
          }
          "settings" = {
            "spacelift" = {
              "autodeploy" = false
              "branch" = "test3"
              "triggers" = [
                "4",
                "5",
                "6",
              ]
              "workspace_enabled" = false
            }
            "version" = 1
          }
          "vars" = {
            "cluster_size" = 2
            "environment" = "uw2"
            "instance_type" = "db.r4.large"
            "namespace" = "eg"
            "region" = "us-west-2"
            "stage" = "uat"
          }
          "workspace" = "uw2-uat"
        }
        "aurora-postgres-2" = {
          "backend" = {
            "acl" = "bucket-owner-full-control"
            "bucket" = "eg-uw2-root-tfstate"
            "dynamodb_table" = "eg-uw2-root-tfstate-lock"
            "encrypt" = true
            "key" = "terraform.tfstate"
            "region" = "us-west-2"
            "role_arn" = "arn:aws:iam::XXXXXXXXXXXX:role/eg-gbl-root-terraform"
            "workspace_key_prefix" = "aurora-postgres"
          }
          "backend_type" = "s3"
          "component" = "aurora-postgres"
          "env" = {
            "ENV_TEST_1" = "test1_override2"
            "ENV_TEST_2" = "test2_override2"
            "ENV_TEST_3" = "test3"
            "ENV_TEST_4" = "test4"
            "ENV_TEST_5" = "test5"
            "ENV_TEST_6" = "test6"
            "ENV_TEST_7" = "test7"
            "ENV_TEST_8" = "test8"
          }
          "settings" = {
            "spacelift" = {
              "autodeploy" = true
              "branch" = "test4"
              "triggers" = [
                "7",
                "8",
                "9",
              ]
              "workspace_enabled" = true
            }
            "version" = 2
          }
          "vars" = {
            "cluster_size" = 3
            "environment" = "uw2"
            "instance_type" = "db.r4.xlarge"
            "namespace" = "eg"
            "region" = "us-west-2"
            "stage" = "uat"
          }
          "workspace" = "uw2-uat-aurora-postgres-2"
        }
```

