### PR TITLE
Remove `count` from stack config data source. Always set `enabled=true` on the `backend` submodule

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,13 +3,13 @@ name: auto-release
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      # Get PR from merged commit to master
+      # Get PR from merged commit to main
       - uses: actions-ecosystem/action-get-merged-pull-request@v1
         id: get-merged-pull-request
         with:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,7 +3,7 @@ name: auto-release
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   publish:

--- a/main.tf
+++ b/main.tf
@@ -1,14 +1,9 @@
-locals {
-  enabled = module.this.enabled
-}
-
 data "utils_stack_config_yaml" "config" {
-  count = local.enabled ? 1 : 0
   input = [for stack in var.stacks : format("%s/%s.yaml", var.stack_config_local_path, stack)]
 }
 
 locals {
-  decoded = try([for i in data.utils_stack_config_yaml.config[0].output : yamldecode(i)], [])
+  decoded = [for i in data.utils_stack_config_yaml.config.output : yamldecode(i)]
 
   config = [
     for stack in local.decoded : {
@@ -16,12 +11,12 @@ locals {
         helmfile = stack.components.helmfile,
         terraform = {
           for k, v in stack.components.terraform : k => {
-            backend      = v.backend,
-            backend_type = v.backend_type,
-            env          = v.env,
-            settings     = v.settings,
-            vars         = v.vars,
-            component    = try(v.component, null),
+            backend      = v.backend
+            backend_type = v.backend_type
+            env          = v.env
+            settings     = v.settings
+            vars         = v.vars
+            component    = try(v.component, null)
             workspace = try(v.backend_type, "") == "remote" ? format("%s-%s", format("%s-%s", try(v.vars.environment, ""), try(v.vars.stage, "")), k) : (
               try(v.component, null) != null ? format("%s-%s-%s", try(v.vars.environment, ""), try(v.vars.stage, ""), k) : (
                 format("%s-%s", try(v.vars.environment, ""), try(v.vars.stage, ""))

--- a/modules/backend/main.tf
+++ b/modules/backend/main.tf
@@ -1,16 +1,14 @@
 locals {
-  enabled = module.this.enabled
-  stack   = var.stack != null ? var.stack : format("%s-%s", module.this.environment, module.this.stage)
+  stack = var.stack != null ? var.stack : format("%s-%s", module.this.environment, module.this.stage)
 }
 
 data "utils_stack_config_yaml" "config" {
-  count = local.enabled ? 1 : 0
   input = [format("%s/%s.yaml", var.stack_config_local_path, local.stack)]
 }
 
 locals {
-  config         = try(yamldecode(data.utils_stack_config_yaml.config[0].output[0]), {})
-  backend_type   = try(local.config["components"][var.component_type][var.component]["backend_type"], "")
-  backend        = try(local.config["components"][var.component_type][var.component]["backend"], {})
+  config         = yamldecode(data.utils_stack_config_yaml.config.output[0])
+  backend_type   = local.config["components"][var.component_type][var.component]["backend_type"]
+  backend        = local.config["components"][var.component_type][var.component]["backend"]
   base_component = try(local.config["components"][var.component_type][var.component]["component"], "")
 }

--- a/modules/env/main.tf
+++ b/modules/env/main.tf
@@ -1,15 +1,13 @@
 locals {
-  enabled = module.this.enabled
-  stack   = var.stack != null ? var.stack : format("%s-%s", module.this.environment, module.this.stage)
+  stack = var.stack != null ? var.stack : format("%s-%s", module.this.environment, module.this.stage)
 }
 
 data "utils_stack_config_yaml" "config" {
-  count = local.enabled ? 1 : 0
   input = [format("%s/%s.yaml", var.stack_config_local_path, local.stack)]
 }
 
 locals {
-  config         = try(yamldecode(data.utils_stack_config_yaml.config[0].output[0]), {})
-  env            = try(local.config["components"][var.component_type][var.component]["env"], {})
+  config         = yamldecode(data.utils_stack_config_yaml.config.output[0])
+  env            = local.config["components"][var.component_type][var.component]["env"]
   base_component = try(local.config["components"][var.component_type][var.component]["component"], "")
 }

--- a/modules/remote-state/main.tf
+++ b/modules/remote-state/main.tf
@@ -1,6 +1,12 @@
 module "backend_config" {
   source = "../backend"
 
+  # Always enable the `backend` module even if `module.this.context` sets `enabled=false`,
+  # because we always need to read the remote state (it needs `environment` and `stage` from the context)
+  # even if a top-level calling module is disabled
+  # (if we want to set `enabled=false` on the top-level modules and then use `terraform apply` to destroy it)
+  enabled = true
+
   stack_config_local_path = var.stack_config_local_path
   stack                   = var.stack
   component               = var.component
@@ -10,8 +16,6 @@ module "backend_config" {
 }
 
 locals {
-  enabled = module.this.enabled
-
   stack = var.stack != null ? var.stack : format("%s-%s", module.this.environment, module.this.stage)
 
   backend_type   = module.backend_config.backend_type
@@ -23,5 +27,5 @@ locals {
     remote = data.terraform_remote_state.remote
   }
 
-  outputs = try(local.remote_states[local.backend_type][0].outputs, {})
+  outputs = local.remote_states[local.backend_type][0].outputs
 }

--- a/modules/remote-state/remote.tf
+++ b/modules/remote-state/remote.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 data "terraform_remote_state" "remote" {
-  count = local.enabled && local.backend_type == "remote" ? 1 : 0
+  count = local.backend_type == "remote" ? 1 : 0
 
   backend = "remote"
 

--- a/modules/remote-state/s3.tf
+++ b/modules/remote-state/s3.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 data "terraform_remote_state" "s3" {
-  count = local.enabled && local.backend_type == "s3" ? 1 : 0
+  count = local.backend_type == "s3" ? 1 : 0
 
   backend = "s3"
 

--- a/modules/settings/main.tf
+++ b/modules/settings/main.tf
@@ -1,15 +1,13 @@
 locals {
-  enabled = module.this.enabled
-  stack   = var.stack != null ? var.stack : format("%s-%s", module.this.environment, module.this.stage)
+  stack = var.stack != null ? var.stack : format("%s-%s", module.this.environment, module.this.stage)
 }
 
 data "utils_stack_config_yaml" "config" {
-  count = local.enabled ? 1 : 0
   input = [format("%s/%s.yaml", var.stack_config_local_path, local.stack)]
 }
 
 locals {
-  config         = try(yamldecode(data.utils_stack_config_yaml.config[0].output[0]), {})
-  settings       = try(local.config["components"][var.component_type][var.component]["settings"], {})
+  config         = yamldecode(data.utils_stack_config_yaml.config.output[0])
+  settings       = local.config["components"][var.component_type][var.component]["settings"]
   base_component = try(local.config["components"][var.component_type][var.component]["component"], "")
 }

--- a/modules/vars/main.tf
+++ b/modules/vars/main.tf
@@ -1,15 +1,13 @@
 locals {
-  enabled = module.this.enabled
-  stack   = var.stack != null ? var.stack : format("%s-%s", module.this.environment, module.this.stage)
+  stack = var.stack != null ? var.stack : format("%s-%s", module.this.environment, module.this.stage)
 }
 
 data "utils_stack_config_yaml" "config" {
-  count = local.enabled ? 1 : 0
   input = [format("%s/%s.yaml", var.stack_config_local_path, local.stack)]
 }
 
 locals {
-  config         = try(yamldecode(data.utils_stack_config_yaml.config[0].output[0]), {})
-  vars           = try(local.config["components"][var.component_type][var.component]["vars"], {})
+  config         = yamldecode(data.utils_stack_config_yaml.config.output[0])
+  vars           = local.config["components"][var.component_type][var.component]["vars"]
   base_component = try(local.config["components"][var.component_type][var.component]["component"], "")
 }


### PR DESCRIPTION
## what
* Remove `count` from stack config data source
* Always set `enabled=true` on the `backend` submodule

## why
* `count` on the data source throws the Terraform "count cannot be computed" error when used from a top-level module which itself uses `count` on other resources
* Always enable the `backend` module even if `module.this.context` sets `enabled=false`, because we always need to read the remote state (it needs `environment` and `stage` from the context) even if a top-level calling module is disabled
(if we want to set `enabled=false` on the top-level modules and then use `terraform apply` to destroy it)
