### PR TITLE
add aws profile support

### DIFF
--- a/modules/remote-state/s3.tf
+++ b/modules/remote-state/s3.tf
@@ -20,7 +20,7 @@ data "terraform_remote_state" "s3" {
     dynamodb_table       = local.backend.dynamodb_table
     region               = local.backend.region
     role_arn             = var.privileged || !contains(keys(local.backend), "role_arn") ? null : local.backend.role_arn
-    profile              = var.privileged || !contains(keys(local.backend), "profile") ? null : local.backend.profil
+    profile              = var.privileged || !contains(keys(local.backend), "profile") ? null : local.backend.profile
     workspace_key_prefix = var.component
   }
 

--- a/modules/remote-state/s3.tf
+++ b/modules/remote-state/s3.tf
@@ -19,8 +19,8 @@ data "terraform_remote_state" "s3" {
     key                  = local.backend.key
     dynamodb_table       = local.backend.dynamodb_table
     region               = local.backend.region
-    role_arn             = var.privileged || !contains(keys(local.backend), "role_arn") ? null : local.backend.role_arn
-    profile              = !var.privileged && contains(keys(local.backend), "profile") ? local.backend.profile : null
+    role_arn             = var.privileged || ! contains(keys(local.backend), "role_arn") ? null : local.backend.role_arn
+    profile              = ! var.privileged && contains(keys(local.backend), "profile") ? local.backend.profile : null
     workspace_key_prefix = var.component
   }
 

--- a/modules/remote-state/s3.tf
+++ b/modules/remote-state/s3.tf
@@ -19,7 +19,7 @@ data "terraform_remote_state" "s3" {
     key                  = local.backend.key
     dynamodb_table       = local.backend.dynamodb_table
     region               = local.backend.region
-    role_arn             = var.privileged || !contains(keys(local.backend), "role_arn") ? null : local.backend.role_arn
+    role_arn             = var.privileged || ! contains(keys(local.backend), "role_arn") ? null : local.backend.role_arn
     profile              = var.privileged || contains(keys(local.backend), "profile") ? local.backend.profile : null
     workspace_key_prefix = var.component
   }

--- a/modules/remote-state/s3.tf
+++ b/modules/remote-state/s3.tf
@@ -19,8 +19,8 @@ data "terraform_remote_state" "s3" {
     key                  = local.backend.key
     dynamodb_table       = local.backend.dynamodb_table
     region               = local.backend.region
-    role_arn             = var.privileged || ! contains(keys(local.backend), "role_arn") ? null : local.backend.role_arn
-    profile              = var.privileged || contains(keys(local.backend), "profile") ? local.backend.profile : null
+    role_arn             = var.privileged || !contains(keys(local.backend), "role_arn") ? null : local.backend.role_arn
+    profile              = !var.privileged && contains(keys(local.backend), "profile") ? local.backend.profile : null
     workspace_key_prefix = var.component
   }
 

--- a/modules/remote-state/s3.tf
+++ b/modules/remote-state/s3.tf
@@ -19,8 +19,8 @@ data "terraform_remote_state" "s3" {
     key                  = local.backend.key
     dynamodb_table       = local.backend.dynamodb_table
     region               = local.backend.region
-    role_arn             = var.privileged || ! contains(keys(local.backend), "role_arn") ? null : local.backend.role_arn
-    profile              = contains(keys(local.backend), "profile") ? local.backend.profile : null
+    role_arn             = var.privileged || !contains(keys(local.backend), "role_arn") ? null : local.backend.role_arn
+    profile              = var.privileged || contains(keys(local.backend), "profile") ? local.backend.profile : null
     workspace_key_prefix = var.component
   }
 

--- a/modules/remote-state/s3.tf
+++ b/modules/remote-state/s3.tf
@@ -19,8 +19,8 @@ data "terraform_remote_state" "s3" {
     key                  = local.backend.key
     dynamodb_table       = local.backend.dynamodb_table
     region               = local.backend.region
-    role_arn             = var.privileged || ! contains(keys(local.backend), "role_arn") ? null : local.backend.role_arn
-    profile              = ! var.privileged && contains(keys(local.backend), "profile") ? local.backend.profile : null
+    role_arn             = var.privileged || !contains(keys(local.backend), "role_arn") ? null : local.backend.role_arn
+    profile              = var.privileged || !contains(keys(local.backend), "profile") ? null : local.backend.profil
     workspace_key_prefix = var.component
   }
 

--- a/modules/remote-state/s3.tf
+++ b/modules/remote-state/s3.tf
@@ -19,7 +19,7 @@ data "terraform_remote_state" "s3" {
     key                  = local.backend.key
     dynamodb_table       = local.backend.dynamodb_table
     region               = local.backend.region
-    role_arn             = var.privileged || !contains(keys(local.backend), "role_arn") ? null : local.backend.role_arn
+    role_arn             = var.privileged || ! contains(keys(local.backend), "role_arn") ? null : local.backend.role_arn
     profile              = contains(keys(local.backend), "profile") ? local.backend.profile : null
     workspace_key_prefix = var.component
   }

--- a/modules/remote-state/s3.tf
+++ b/modules/remote-state/s3.tf
@@ -19,8 +19,8 @@ data "terraform_remote_state" "s3" {
     key                  = local.backend.key
     dynamodb_table       = local.backend.dynamodb_table
     region               = local.backend.region
-    role_arn             = var.privileged || !contains(keys(local.backend), "role_arn") ? null : local.backend.role_arn
-    profile              = var.privileged || !contains(keys(local.backend), "profile") ? null : local.backend.profile
+    role_arn             = var.privileged || ! contains(keys(local.backend), "role_arn") ? null : local.backend.role_arn
+    profile              = var.privileged || ! contains(keys(local.backend), "profile") ? null : local.backend.profile
     workspace_key_prefix = var.component
   }
 

--- a/modules/remote-state/s3.tf
+++ b/modules/remote-state/s3.tf
@@ -19,7 +19,8 @@ data "terraform_remote_state" "s3" {
     key                  = local.backend.key
     dynamodb_table       = local.backend.dynamodb_table
     region               = local.backend.region
-    role_arn             = var.privileged ? null : local.backend.role_arn
+    role_arn             = var.privileged || !contains(keys(local.backend), "role_arn") ? null : local.backend.role_arn
+    profile              = contains(keys(local.backend), "profile") ? local.backend.profile : null
     workspace_key_prefix = var.component
   }
 


### PR DESCRIPTION
## what
* add support for AWS `profile` in `remote-state`

## why
* to allow support for specifying an AWS Profile name instead of a `role_arn` to access the `s3` backend