### PR TITLE
[remote-state] ignore `enabled`, allow `bypass`

### DIFF
--- a/modules/remote-state/main.tf
+++ b/modules/remote-state/main.tf
@@ -1,5 +1,6 @@
-module "backend_config" {
-  source = "../backend"
+module "always" {
+  source  = "cloudposse/label/null"
+  version = "0.24.1"
 
   # Always enable the `backend` module even if `module.this.context` sets `enabled=false`,
   # because we always need to read the remote state (it needs `environment` and `stage` from the context)
@@ -7,25 +8,33 @@ module "backend_config" {
   # (if we want to set `enabled=false` on the top-level modules and then use `terraform apply` to destroy it)
   enabled = true
 
+  context = module.this.context
+}
+
+module "backend_config" {
+  source = "../backend"
+
   stack_config_local_path = var.stack_config_local_path
   stack                   = var.stack
   component               = var.component
   component_type          = var.component_type
 
-  context = module.this.context
+  context = module.always.context
 }
 
 locals {
-  stack = var.stack != null ? var.stack : format("%s-%s", module.this.environment, module.this.stage)
+  stack = var.stack != null ? var.stack : format("%s-%s", module.always.environment, module.always.stage)
 
   backend_type   = module.backend_config.backend_type
   backend        = module.backend_config.backend
   base_component = module.backend_config.base_component
+
+  remote_state_enabled = ! var.bypass
 
   remote_states = {
     s3     = data.terraform_remote_state.s3
     remote = data.terraform_remote_state.remote
   }
 
-  outputs = local.remote_states[local.backend_type][0].outputs
+  outputs = var.bypass ? var.defaults : local.remote_states[local.backend_type][0].outputs
 }

--- a/modules/remote-state/remote.tf
+++ b/modules/remote-state/remote.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 data "terraform_remote_state" "remote" {
-  count = local.backend_type == "remote" ? 1 : 0
+  count = local.remote_state_enabled && local.backend_type == "remote" ? 1 : 0
 
   backend = "remote"
 

--- a/modules/remote-state/s3.tf
+++ b/modules/remote-state/s3.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 data "terraform_remote_state" "s3" {
-  count = local.backend_type == "s3" ? 1 : 0
+  count = local.remote_state_enabled && local.backend_type == "s3" ? 1 : 0
 
   backend = "s3"
 

--- a/modules/remote-state/variables.tf
+++ b/modules/remote-state/variables.tf
@@ -39,6 +39,12 @@ variable "workspace" {
   default     = null
 }
 
+variable "bypass" {
+  type        = bool
+  description = "Set to true to skip looking up the remote state and just return the defaults."
+  default     = false
+}
+
 variable "include_component_in_workspace_name" {
   type        = bool
   description = "Whether to include the component name in the workspace name. This variable, if set, overrides the `component` attribute in YAML stack configs"


### PR DESCRIPTION
## what
- [remote-state] ignore `enabled`
- [remote-state] allow `bypass`allow `bypass`

## why
- Modules that use `remote-state` usually need it to work even when the module itself is disabled
- Modules that really know what they are doing need a replacement for `enabled` to prevent the lookup of the remote state 