### PR TITLE
Work around requirement that objects match exactly

### DIFF
--- a/modules/remote-state/main.tf
+++ b/modules/remote-state/main.tf
@@ -34,7 +34,8 @@ locals {
   remote_states = {
     s3     = data.terraform_remote_state.s3
     remote = data.terraform_remote_state.remote
+    bypass = [{ outputs = var.defaults }]
   }
 
-  outputs = var.bypass ? var.defaults : local.remote_states[local.backend_type][0].outputs
+  outputs = local.remote_states[var.bypass ? "bypass" : local.backend_type][0].outputs
 }


### PR DESCRIPTION
## what
- Work around requirement that objects match exactly when used in a tertiary conditional expression

## why
- We do not want to predict or limit the structure of a remote state

## references
- https://github.com/hashicorp/terraform/issues/23364

