### PR TITLE
Update `spacelift` module

### DIFF
--- a/examples/spacelift/fixtures.tfvars
+++ b/examples/spacelift/fixtures.tfvars
@@ -2,6 +2,8 @@ enabled = true
 
 stack_config_path_template = "stacks/%s.yaml"
 
+stack_config_path = "./stacks"
+
 stacks = [
   "uw2-dev",
   "uw2-prod",

--- a/examples/spacelift/main.tf
+++ b/examples/spacelift/main.tf
@@ -3,6 +3,7 @@ module "spacelift" {
 
   stacks                            = var.stacks
   stack_config_path_template        = var.stack_config_path_template
+  stack_config_path                 = var.stack_config_path
   stack_deps_processing_enabled     = var.stack_deps_processing_enabled
   component_deps_processing_enabled = var.component_deps_processing_enabled
   imports_processing_enabled        = var.imports_processing_enabled

--- a/examples/spacelift/variables.tf
+++ b/examples/spacelift/variables.tf
@@ -26,3 +26,9 @@ variable "stack_config_path_template" {
   description = "Stack config path template"
   default     = "stacks/%s.yaml"
 }
+
+variable "stack_config_path" {
+  type        = string
+  description = "Relative path to YAML config files"
+  default     = "./stacks"
+}

--- a/modules/spacelift/README.md
+++ b/modules/spacelift/README.md
@@ -19,6 +19,7 @@ The following example loads the infrastructure YAML stack configs and returns Sp
       ]
   
       stack_config_path_template        = "stacks/%s.yaml"
+      stack_config_path                 = "./stacks"
       component_deps_processing_enabled = true
     
       context = module.this.context

--- a/modules/spacelift/main.tf
+++ b/modules/spacelift/main.tf
@@ -1,5 +1,5 @@
 data "utils_spacelift_stack_config" "spacelift_stacks" {
-  input                      = [for stack in var.stacks : format(var.stack_config_path_template, stack)]
+  input                      = [for stack in var.stacks : format("%s/%s.yaml", var.stack_config_path, stack)]
   process_stack_deps         = var.stack_deps_processing_enabled
   process_component_deps     = var.component_deps_processing_enabled
   process_imports            = var.imports_processing_enabled

--- a/modules/spacelift/variables.tf
+++ b/modules/spacelift/variables.tf
@@ -26,3 +26,9 @@ variable "stack_config_path_template" {
   description = "Stack config path template"
   default     = "stacks/%s.yaml"
 }
+
+variable "stack_config_path" {
+  type        = string
+  description = "Relative path to YAML config files"
+  default     = "./stacks"
+}


### PR DESCRIPTION
## what
* Update `spacelift` module
* Add `stack_config_path` variable

## why
* Need a separate variable with a relative path to the stack config folder
* `stack_config_path_template` is used to create Spacelift stack labels, it does not specify the relative path to the YAML config files

