### PR TITLE
Remove unused and deprecated template provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,6 @@ Available targets:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.2 |
 | <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.8.0 |
 
 ## Providers
@@ -428,7 +427,6 @@ For additional context, refer to some of these links.
 - [Terraform Module Requirements](https://www.terraform.io/docs/registry/modules/publish.html#requirements) - HashiCorp's guidance on all the requirements for publishing a module. Meeting the requirements for publishing a module is extremely easy.
 - [Terraform Version Pinning](https://www.terraform.io/docs/configuration/terraform.html#specifying-a-required-terraform-version) - The required_version setting can be used to constrain which versions of the Terraform CLI can be used with your configuration.
 - [Terraform `templatefile` Function](https://www.terraform.io/docs/configuration/functions/templatefile.html) - `templatefile` reads the file at the given path and renders its content as a template using a supplied set of template variables.
-- [Terraform `template_file` data source](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) - The `template_file` data source renders a template from a template string, which is usually loaded from an external file.
 
 
 ## Help

--- a/README.yaml
+++ b/README.yaml
@@ -91,9 +91,6 @@ references:
   - name: "Terraform `templatefile` Function"
     description: "`templatefile` reads the file at the given path and renders its content as a template using a supplied set of template variables."
     url: "https://www.terraform.io/docs/configuration/functions/templatefile.html"
-  - name: "Terraform `template_file` data source"
-    description: "The `template_file` data source renders a template from a template string, which is usually loaded from an external file."
-    url: "https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file"
 
 # Short description of this project
 description: |-
@@ -127,7 +124,6 @@ usage: |-
 
   For an example on how to process `vars`, `settings`, `env` and `backend` configurations for all Terraform and helmfile components for a list of stacks,
   see [examples/stacks](examples/stacks).
-
 
 # Example usage
 examples: |-

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -6,7 +6,6 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.2 |
 | <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.8.0 |
 
 ## Providers

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/local"
       version = ">= 1.3"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.2"
-    }
     external = {
       source  = "hashicorp/external"
       version = ">= 2.0"

--- a/examples/remote-state/versions.tf
+++ b/examples/remote-state/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/local"
       version = ">= 1.3"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.2"
-    }
     external = {
       source  = "hashicorp/external"
       version = ">= 2.0"

--- a/examples/spacelift/versions.tf
+++ b/examples/spacelift/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/local"
       version = ">= 1.3"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.2"
-    }
     external = {
       source  = "hashicorp/external"
       version = ">= 2.0"

--- a/examples/stacks/versions.tf
+++ b/examples/stacks/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/local"
       version = ">= 1.3"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.2"
-    }
     external = {
       source  = "hashicorp/external"
       version = ">= 2.0"

--- a/modules/backend/versions.tf
+++ b/modules/backend/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/local"
       version = ">= 1.3"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.2"
-    }
     external = {
       source  = "hashicorp/external"
       version = ">= 2.0"

--- a/modules/env/versions.tf
+++ b/modules/env/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/local"
       version = ">= 1.3"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.2"
-    }
     external = {
       source  = "hashicorp/external"
       version = ">= 2.0"

--- a/modules/remote-state/versions.tf
+++ b/modules/remote-state/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/local"
       version = ">= 1.3"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.2"
-    }
     external = {
       source  = "hashicorp/external"
       version = ">= 2.0"

--- a/modules/settings/versions.tf
+++ b/modules/settings/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/local"
       version = ">= 1.3"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.2"
-    }
     external = {
       source  = "hashicorp/external"
       version = ">= 2.0"

--- a/modules/spacelift/versions.tf
+++ b/modules/spacelift/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/local"
       version = ">= 1.3"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.2"
-    }
     external = {
       source  = "hashicorp/external"
       version = ">= 2.0"

--- a/modules/vars/versions.tf
+++ b/modules/vars/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/local"
       version = ">= 1.3"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.2"
-    }
     external = {
       source  = "hashicorp/external"
       version = ">= 2.0"

--- a/versions.tf
+++ b/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/local"
       version = ">= 1.3"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.2"
-    }
     external = {
       source  = "hashicorp/external"
       version = ">= 2.0"


### PR DESCRIPTION
## what
* Remove any references to the `template` provider

## why
* The `template` provider is deprecated and no binaries exist for `darwin/arm64`
* The provider is not used in the module or any submodules

## references
* [Provider documentation](https://registry.terraform.io/providers/hashicorp/template/latest/docs)

