### PR TITLE
Fix backend lookup error

### DIFF
--- a/modules/backend/main.tf
+++ b/modules/backend/main.tf
@@ -11,6 +11,6 @@ locals {
   base_component = try(local.config["components"][var.component_type][var.component]["component"], "")
 
   final_component = coalesce(local.base_component, var.component)
-  backend_type    = local.config["components"][var.component_type][local.final_component]["backend_type"]
-  backend         = local.config["components"][var.component_type][local.final_component]["backend"]
+  backend_type    = try(local.config["components"][var.component_type][local.final_component]["backend_type"], "")
+  backend         = try(local.config["components"][var.component_type][local.final_component]["backend"], "")
 }

--- a/modules/remote-state/main.tf
+++ b/modules/remote-state/main.tf
@@ -38,5 +38,5 @@ locals {
   }
 
   remote_state_backend_key = var.bypass ? "bypass" : local.backend_type
-  outputs = try(length(local.remote_state_backend_key), 0) > 0 ? local.remote_states[local.remote_state_backend_key][0].outputs : {}
+  outputs                  = try(length(local.remote_state_backend_key), 0) > 0 ? local.remote_states[local.remote_state_backend_key][0].outputs : {}
 }

--- a/modules/remote-state/main.tf
+++ b/modules/remote-state/main.tf
@@ -37,5 +37,6 @@ locals {
     bypass = [{ outputs = var.defaults }]
   }
 
-  outputs = local.remote_states[var.bypass ? "bypass" : local.backend_type][0].outputs
+  remote_state_backend_key = var.bypass ? "bypass" : local.backend_type
+  outputs = try(length(local.remote_state_backend_key), 0) > 0 ? local.remote_states[local.remote_state_backend_key][0].outputs : {}
 }


### PR DESCRIPTION
## what
* Fix backend lookup error

## why
* Awful awful awful error

```
│ Error: Invalid index
│
│   on .terraform/modules/sso/modules/backend/main.tf line 14, in locals:
│   14:   backend_type    = local.config["components"][var.component_type][local.final_component]["backend_type"]
│     ├────────────────
│     │ local.config["components"] is object with 2 attributes
│     │ local.final_component is "sso"
│     │ var.component_type is "terraform"
│
│ The given key does not identify an element in this collection value.
```

This comes up when you have to plan the `iam-delegated-roles` component in a stage that doesn't have the `tfstate-backend` (defaultregion-root) or the `sso` (gbl-identity) remote states.

## references
N/A

