### PR TITLE
Set remote-state.outputs to null

### DIFF
--- a/modules/remote-state/main.tf
+++ b/modules/remote-state/main.tf
@@ -38,5 +38,5 @@ locals {
   }
 
   remote_state_backend_key = var.bypass ? "bypass" : local.backend_type
-  outputs                  = try(length(local.remote_state_backend_key), 0) > 0 ? local.remote_states[local.remote_state_backend_key][0].outputs : {}
+  outputs                  = try(length(local.remote_state_backend_key), 0) > 0 ? local.remote_states[local.remote_state_backend_key][0].outputs : null
 }


### PR DESCRIPTION
## what
* Set remote-state.outputs to null

To test

```hcl
module "sso" {
  source = "git::ssh://git@github.com:cloudposse/terraform-yaml-stack-config.git/modules/remote-state?ref=remote-state-outputs-null"

  # ...
}
```

## why
* Avoid `Error: Inconsistent conditional result types`

## references
* Previous PR https://github.com/cloudposse/terraform-yaml-stack-config/pull/32

