### PR TITLE
Improvements and new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,13 +346,13 @@ Available targets:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
-| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.16.0 |
+| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.17.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_utils"></a> [utils](#provider\_utils) | >= 0.16.0 |
+| <a name="provider_utils"></a> [utils](#provider\_utils) | >= 0.17.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -6,13 +6,13 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
-| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.16.0 |
+| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.17.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_utils"></a> [utils](#provider\_utils) | >= 0.16.0 |
+| <a name="provider_utils"></a> [utils](#provider\_utils) | >= 0.17.0 |
 
 ## Modules
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.16.0"
+      version = ">= 0.17.0"
     }
   }
 }

--- a/examples/remote-state/atmos.yaml
+++ b/examples/remote-state/atmos.yaml
@@ -18,7 +18,7 @@ components:
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT` ENV var, or `--deploy-run-init` command-line argument
     deploy_run_init: true
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_AUTO_GENERATE_BACKEND_FILE` ENV var, or `--auto-generate-backend-file` command-line argument
-    auto_generate_backend_file: true
+    auto_generate_backend_file: false
   helmfile:
     # Can also be set using `ATMOS_COMPONENTS_HELMFILE_BASE_PATH` ENV var, or `--helmfile-dir` command-line argument
     # Supports both absolute and relative paths

--- a/examples/remote-state/atmos.yaml
+++ b/examples/remote-state/atmos.yaml
@@ -17,6 +17,8 @@ components:
     apply_auto_approve: false
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT` ENV var, or `--deploy-run-init` command-line argument
     deploy_run_init: true
+    # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_AUTO_GENERATE_BACKEND_FILE` ENV var, or `--auto-generate-backend-file` command-line argument
+    auto_generate_backend_file: true
   helmfile:
     # Can also be set using `ATMOS_COMPONENTS_HELMFILE_BASE_PATH` ENV var, or `--helmfile-dir` command-line argument
     # Supports both absolute and relative paths

--- a/examples/remote-state/stacks/catalog/terraform/test-component-override.yaml
+++ b/examples/remote-state/stacks/catalog/terraform/test-component-override.yaml
@@ -16,6 +16,7 @@ components:
       component: "test/test-component"
       # Other variables can be overridden here
       vars: { }
+      # Override backend for this component
       backend_type: static # s3, remote, vault, static, etc.
       backend:
         static:
@@ -24,3 +25,11 @@ components:
           val3: true
           val4: ""
           val5: null
+      # Override remote state backend for this component
+      remote_state_backend_type: static # s3, remote, vault, static, etc.
+      remote_state_backend:
+        static:
+          val1: true
+          val2: "2"
+          val3: 3
+          val4: null

--- a/examples/remote-state/stacks/catalog/terraform/test-component-override.yaml
+++ b/examples/remote-state/stacks/catalog/terraform/test-component-override.yaml
@@ -29,7 +29,8 @@ components:
       remote_state_backend_type: static # s3, remote, vault, static, etc.
       remote_state_backend:
         static:
-          val1: true
+          val1: 1
           val2: "2"
-          val3: 3
-          val4: null
+          val3: true
+          val4: ""
+          val5: 5

--- a/examples/remote-state/stacks/catalog/terraform/test-component.yaml
+++ b/examples/remote-state/stacks/catalog/terraform/test-component.yaml
@@ -12,6 +12,9 @@ components:
       backend:
         s3:
           workspace_key_prefix: test-test-component
+      remote_state_backend:
+        s3:
+          workspace_key_prefix: test-test-component
       settings:
         spacelift:
           workspace_enabled: true

--- a/examples/remote-state/stacks/catalog/terraform/top-level-component1.yaml
+++ b/examples/remote-state/stacks/catalog/terraform/top-level-component1.yaml
@@ -12,6 +12,9 @@ components:
       backend:
         s3:
           workspace_key_prefix: top-level-component1
+      remote_state_backend:
+        s3:
+          workspace_key_prefix: top-level-component1
       settings:
         spacelift:
           workspace_enabled: true

--- a/examples/remote-state/stacks/catalog/terraform/vpc.yaml
+++ b/examples/remote-state/stacks/catalog/terraform/vpc.yaml
@@ -4,6 +4,9 @@ components:
       backend:
         s3:
           workspace_key_prefix: infra-vpc
+      remote_state_backend:
+        s3:
+          workspace_key_prefix: infra-vpc
       settings:
         spacelift:
           workspace_enabled: true

--- a/examples/remote-state/stacks/globals/globals.yaml
+++ b/examples/remote-state/stacks/globals/globals.yaml
@@ -3,6 +3,7 @@ vars:
 
 terraform:
   vars: {}
+
   backend_type: s3 # s3, remote, vault, etc.
   backend:
     s3:
@@ -15,6 +16,17 @@ terraform:
       region: "us-east-2"
     remote:
     vault:
+
+  remote_state_backend_type: s3 # s3, remote, vault, static, etc.
+  remote_state_backend:
+    s3:
+      encrypt: true
+      bucket: "eg-ue2-root-tfstate"
+      key: "terraform.tfstate"
+      dynamodb_table: "eg-ue2-root-tfstate-lock"
+      profile: "eg-gbl-root-terraform"
+      acl: "bucket-owner-full-control"
+      region: "us-east-2"
 
 helmfile:
   vars: {}

--- a/examples/remote-state/versions.tf
+++ b/examples/remote-state/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.16.0"
+      version = ">= 0.17.0"
     }
   }
 }

--- a/examples/spacelift/versions.tf
+++ b/examples/spacelift/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.16.0"
+      version = ">= 0.17.0"
     }
   }
 }

--- a/examples/stack/versions.tf
+++ b/examples/stack/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.16.0"
+      version = ">= 0.17.0"
     }
   }
 }

--- a/examples/stacks/versions.tf
+++ b/examples/stacks/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.16.0"
+      version = ">= 0.17.0"
     }
   }
 }

--- a/modules/backend/versions.tf
+++ b/modules/backend/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.16.0"
+      version = ">= 0.17.0"
     }
   }
 }

--- a/modules/env/versions.tf
+++ b/modules/env/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.16.0"
+      version = ">= 0.17.0"
     }
   }
 }

--- a/modules/remote-state/main.tf
+++ b/modules/remote-state/main.tf
@@ -18,7 +18,7 @@ locals {
   workspace            = local.config.workspace
   workspace_key_prefix = lookup(local.backend, "workspace_key_prefix", null)
 
-  remote_state_enabled = !var.bypass
+  remote_state_enabled = ! var.bypass
 
   remote_states = {
     s3     = data.terraform_remote_state.s3

--- a/modules/remote-state/main.tf
+++ b/modules/remote-state/main.tf
@@ -7,13 +7,18 @@ data "utils_component_config" "config" {
 }
 
 locals {
-  config               = yamldecode(data.utils_component_config.config.output)
-  backend_type         = local.config.backend_type
-  backend              = local.config.backend
+  config = yamldecode(data.utils_component_config.config.output)
+
+  remote_state_backend_type = try(local.config.remote_state_backend_type, "")
+  backend_type              = coalesce(local.remote_state_backend_type, local.config.backend_type)
+
+  remote_state_backend = try(local.config.remote_state_backend, null) != null ? local.config.remote_state_backend : null
+  backend              = local.remote_state_backend != null ? local.remote_state_backend : local.config.backend
+
   workspace            = local.config.workspace
   workspace_key_prefix = lookup(local.backend, "workspace_key_prefix", null)
 
-  remote_state_enabled = ! var.bypass
+  remote_state_enabled = !var.bypass
 
   remote_states = {
     s3     = data.terraform_remote_state.s3

--- a/modules/remote-state/versions.tf
+++ b/modules/remote-state/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.16.0"
+      version = ">= 0.17.0"
     }
   }
 }

--- a/modules/settings/versions.tf
+++ b/modules/settings/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.16.0"
+      version = ">= 0.17.0"
     }
   }
 }

--- a/modules/spacelift/versions.tf
+++ b/modules/spacelift/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.16.0"
+      version = ">= 0.17.0"
     }
   }
 }

--- a/modules/vars/versions.tf
+++ b/modules/vars/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.16.0"
+      version = ">= 0.17.0"
     }
   }
 }

--- a/test/src/examples_remote_state_test.go
+++ b/test/src/examples_remote_state_test.go
@@ -36,7 +36,7 @@ func TestExamplesRemoteState(t *testing.T) {
 	assert.Equal(t, "2", remoteStateUsingStack["val2"])
 	assert.Equal(t, true, remoteStateUsingStack["val3"])
 	assert.Equal(t, "", remoteStateUsingStack["val4"])
-	assert.Equal(t, nil, remoteStateUsingStack["val5"])
+	assert.Equal(t, float64(5), remoteStateUsingStack["val5"])
 
 	terraform.OutputStruct(t, terraformOptions, "remote_state_using_context", &output)
 	remoteStateUsingContext := output.(map[string]interface{})
@@ -47,5 +47,5 @@ func TestExamplesRemoteState(t *testing.T) {
 	assert.Equal(t, "2", remoteStateUsingContext["val2"])
 	assert.Equal(t, true, remoteStateUsingContext["val3"])
 	assert.Equal(t, "", remoteStateUsingContext["val4"])
-	assert.Equal(t, nil, remoteStateUsingContext["val5"])
+	assert.Equal(t, float64(5), remoteStateUsingContext["val5"])
 }

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.16.0"
+      version = ">= 0.17.0"
     }
   }
 }


### PR DESCRIPTION
## what
* Improvements and new features

## why

* Add `remote_state_backend` and `remote_state_backend_type` YAML config sections. They can be used to specify a different backend (different attributes, or even a completely different backend type) for remote state. It's useful for the privileged components where we use different attributes (e.g. `role_arn` or `profile`) during the cold-start and during the normal operations to get the remote state of the privileged components

```
      # Override backend for this component
      backend_type: static # s3, remote, vault, static, etc.
      backend:
        static:
          val1: 1
          val2: "2"
          val3: true
          val4: ""
          val5: null
      # Override remote state backend for this component
      remote_state_backend_type: static # s3, remote, vault, static, etc.
      remote_state_backend:
        static:
          val1: 1
          val2: "2"
          val3: true
          val4: ""
          val5: 5
```

The new `remote_state_backend` section in YAML is similar to the `backend` section - you can specify it in globals, stage globals, or override per component (which all gets deep-merged into the final remote state backend for the component). The two sections are separate and the attributes from them are not merged together

