### PR TITLE
Update `remote-state` module

### DIFF
--- a/modules/remote-state/main.tf
+++ b/modules/remote-state/main.tf
@@ -26,7 +26,7 @@ locals {
   workspace            = local.config.workspace
   workspace_key_prefix = lookup(local.backend, "workspace_key_prefix", null)
 
-  remote_state_enabled = !var.bypass
+  remote_state_enabled = ! var.bypass
 
   remote_states = {
     s3     = data.terraform_remote_state.s3


### PR DESCRIPTION
## what
* Update `remote-state` module

## why
* If `remote_state_backend` is not declared in YAML config, the default value will be an empty map `{}`, causing the condition to always be true and not defaulting to `backend`
* The `?` operator in some instances (depending on the condition) changes the types of all items of the map to all `strings`
