### PR TITLE
Update `utils` provider. Add `ignore_errors` variable to `remote-state`

### DIFF
--- a/.github/workflows/auto-readme.yml
+++ b/.github/workflows/auto-readme.yml
@@ -1,7 +1,16 @@
 name: "auto-readme"
 on:
   schedule:
-  # Update README.md nightly
+  # Example of job definition:
+  # .---------------- minute (0 - 59)
+  # |  .------------- hour (0 - 23)
+  # |  |  .---------- day of month (1 - 31)
+  # |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+  # |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+  # |  |  |  |  |
+  # *  *  *  *  * user-name command to be executed
+
+  # Update README.md nightly at 4am UTC
   - cron:  '0 4 * * *'
 
 jobs:
@@ -20,7 +29,7 @@ jobs:
         make init
         make readme/build
         # Ignore changes if they are only whitespace
-        git diff --ignore-all-space --ignore-blank-lines --quiet README.md && git restore README.md
+        git diff --ignore-all-space --ignore-blank-lines --quiet README.md && { git restore README.md; echo Ignoring whitespace-only changes in README; }
 
     - name: Create Pull Request
       # This action will not create or change a pull request if there are no changes to make.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 Cloud Posse, LLC
+   Copyright 2021-2022 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -346,13 +346,13 @@ Available targets:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
-| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.17.7 |
+| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.17.15 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_utils"></a> [utils](#provider\_utils) | >= 0.17.7 |
+| <a name="provider_utils"></a> [utils](#provider\_utils) | >= 0.17.15 |
 
 ## Modules
 
@@ -504,7 +504,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2021-2021 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2021-2022 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -6,13 +6,13 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
-| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.17.7 |
+| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.17.15 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_utils"></a> [utils](#provider\_utils) | >= 0.17.7 |
+| <a name="provider_utils"></a> [utils](#provider\_utils) | >= 0.17.15 |
 
 ## Modules
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.7"
+      version = ">= 0.17.15"
     }
   }
 }

--- a/examples/remote-state/atmos.yaml
+++ b/examples/remote-state/atmos.yaml
@@ -8,11 +8,20 @@
 # It supports POSIX-style Globs for file names/paths (double-star `**` is supported)
 # https://en.wikipedia.org/wiki/Glob_(programming)
 
+# Base path for components and stacks configurations.
+# Can also be set using `ATMOS_BASE_PATH` ENV var, or `--base-path` command-line argument.
+# Supports both absolute and relative paths.
+# If not provided or is an empty string, `components.terraform.base_path`, `components.helmfile.base_path` and `stacks.base_path`
+# are independent settings (supporting both absolute and relative paths).
+# If `base_path` is provided, `components.terraform.base_path`, `components.helmfile.base_path` and `stacks.base_path`
+# are considered paths relative to `base_path`.
+base_path: "."
+
 components:
   terraform:
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_BASE_PATH` ENV var, or `--terraform-dir` command-line argument
     # Supports both absolute and relative paths
-    base_path: "./components/terraform"
+    base_path: "components/terraform"
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_APPLY_AUTO_APPROVE` ENV var
     apply_auto_approve: false
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT` ENV var, or `--deploy-run-init` command-line argument
@@ -22,7 +31,7 @@ components:
   helmfile:
     # Can also be set using `ATMOS_COMPONENTS_HELMFILE_BASE_PATH` ENV var, or `--helmfile-dir` command-line argument
     # Supports both absolute and relative paths
-    base_path: "./components/helmfile"
+    base_path: "components/helmfile"
     # Can also be set using `ATMOS_COMPONENTS_HELMFILE_KUBECONFIG_PATH` ENV var
     kubeconfig_path: "/dev/shm"
     # Can also be set using `ATMOS_COMPONENTS_HELMFILE_HELM_AWS_PROFILE_PATTERN` ENV var
@@ -33,7 +42,7 @@ components:
 stacks:
   # Can also be set using `ATMOS_STACKS_BASE_PATH` ENV var, or `--config-dir` and `--stacks-dir` command-line arguments
   # Supports both absolute and relative paths
-  base_path: "./stacks"
+  base_path: "stacks"
   # Can also be set using `ATMOS_STACKS_INCLUDED_PATHS` ENV var (comma-separated values string)
   included_paths:
     - "**/*"

--- a/examples/remote-state/main.tf
+++ b/examples/remote-state/main.tf
@@ -17,3 +17,18 @@ module "remote_state_using_context" {
 
   context = module.this.context
 }
+
+module "remote_state_using_context_ignore_errors" {
+  source = "../../modules/remote-state"
+
+  # Use a wrong component for testing
+  # If `ignore_errors = false`, the `utils` provider will throw the error: Could not find config for the component 'test/test-component-override-wrong' in the stack 'tenant1-ue2-dev'
+  # Note that terraform `try()` does not catch errors from providers, so `try(module.remote_state_using_context_ignore_errors.outputs, {})` will not work
+  ignore_errors = true
+  component     = "test/test-component-override-wrong"
+  tenant        = "tenant1"
+  environment   = "ue2"
+  stage         = "dev"
+
+  context = module.this.context
+}

--- a/examples/remote-state/outputs.tf
+++ b/examples/remote-state/outputs.tf
@@ -7,3 +7,8 @@ output "remote_state_using_context" {
   value       = module.remote_state_using_context.outputs
   description = "Component remote state using the provided context"
 }
+
+output "remote_state_using_context_ignore_errors" {
+  value       = module.remote_state_using_context_ignore_errors.outputs
+  description = "Component remote state using wrong component. Errors are ignored in the 'utils' provider"
+}

--- a/examples/remote-state/versions.tf
+++ b/examples/remote-state/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.7"
+      version = ">= 0.17.15"
     }
   }
 }

--- a/examples/spacelift/atmos.yaml
+++ b/examples/spacelift/atmos.yaml
@@ -8,11 +8,20 @@
 # It supports POSIX-style Globs for file names/paths (double-star `**` is supported)
 # https://en.wikipedia.org/wiki/Glob_(programming)
 
+# Base path for components and stacks configurations.
+# Can also be set using `ATMOS_BASE_PATH` ENV var, or `--base-path` command-line argument.
+# Supports both absolute and relative paths.
+# If not provided or is an empty string, `components.terraform.base_path`, `components.helmfile.base_path` and `stacks.base_path`
+# are independent settings (supporting both absolute and relative paths).
+# If `base_path` is provided, `components.terraform.base_path`, `components.helmfile.base_path` and `stacks.base_path`
+# are considered paths relative to `base_path`.
+base_path: "."
+
 components:
   terraform:
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_BASE_PATH` ENV var, or `--terraform-dir` command-line argument
     # Supports both absolute and relative paths
-    base_path: "./components/terraform"
+    base_path: "components/terraform"
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_APPLY_AUTO_APPROVE` ENV var
     apply_auto_approve: false
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT` ENV var, or `--deploy-run-init` command-line argument
@@ -22,7 +31,7 @@ components:
   helmfile:
     # Can also be set using `ATMOS_COMPONENTS_HELMFILE_BASE_PATH` ENV var, or `--helmfile-dir` command-line argument
     # Supports both absolute and relative paths
-    base_path: "./components/helmfile"
+    base_path: "components/helmfile"
     # Can also be set using `ATMOS_COMPONENTS_HELMFILE_KUBECONFIG_PATH` ENV var
     kubeconfig_path: "/dev/shm"
     # Can also be set using `ATMOS_COMPONENTS_HELMFILE_HELM_AWS_PROFILE_PATTERN` ENV var
@@ -33,7 +42,7 @@ components:
 stacks:
   # Can also be set using `ATMOS_STACKS_BASE_PATH` ENV var, or `--config-dir` and `--stacks-dir` command-line arguments
   # Supports both absolute and relative paths
-  base_path: "./stacks"
+  base_path: "stacks"
   # Can also be set using `ATMOS_STACKS_INCLUDED_PATHS` ENV var (comma-separated values string)
   included_paths:
     - "**/*"

--- a/examples/spacelift/versions.tf
+++ b/examples/spacelift/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.7"
+      version = ">= 0.17.15"
     }
   }
 }

--- a/examples/stack/versions.tf
+++ b/examples/stack/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.7"
+      version = ">= 0.17.15"
     }
   }
 }

--- a/examples/stacks/versions.tf
+++ b/examples/stacks/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.7"
+      version = ">= 0.17.15"
     }
   }
 }

--- a/modules/backend/main.tf
+++ b/modules/backend/main.tf
@@ -1,6 +1,7 @@
 data "utils_component_config" "config" {
-  component = var.component
-  stack     = var.stack
+  component     = var.component
+  stack         = var.stack
+  ignore_errors = var.ignore_errors
 }
 
 locals {

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -7,3 +7,9 @@ variable "stack" {
   type        = string
   description = "Stack name"
 }
+
+variable "ignore_errors" {
+  type        = bool
+  description = "Set to true to ignore errors from the 'utils' provider (if the component is not found in the stack)"
+  default     = false
+}

--- a/modules/backend/versions.tf
+++ b/modules/backend/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.7"
+      version = ">= 0.17.15"
     }
   }
 }

--- a/modules/env/versions.tf
+++ b/modules/env/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.7"
+      version = ">= 0.17.15"
     }
   }
 }

--- a/modules/remote-state/main.tf
+++ b/modules/remote-state/main.tf
@@ -1,32 +1,33 @@
 data "utils_component_config" "config" {
-  component   = var.component
-  stack       = var.stack
-  tenant      = module.always.tenant
-  environment = module.always.environment
-  stage       = module.always.stage
+  component     = var.component
+  stack         = var.stack
+  tenant        = module.always.tenant
+  environment   = module.always.environment
+  stage         = module.always.stage
+  ignore_errors = var.ignore_errors
 }
 
 locals {
   config = yamldecode(data.utils_component_config.config.output)
 
   remote_state_backend_type = try(local.config.remote_state_backend_type, "")
-  backend_type              = coalesce(local.remote_state_backend_type, local.config.backend_type)
+  backend_type              = try(coalesce(local.remote_state_backend_type, local.config.backend_type), "")
 
   # If `config.remote_state_backend` is not declared in YAML config, the default value will be an empty map `{}`
   backend_config_key = try(local.config.remote_state_backend, null) != null && try(length(local.config.remote_state_backend), 0) > 0 ? "remote_state_backend" : "backend"
 
   # This is used because the `?` operator in some instances (depending on the condition) changes the types of all items of the map to all `strings`
   backend_configs = {
-    backend              = local.config.backend
-    remote_state_backend = local.config.remote_state_backend
+    backend              = lookup(local.config, "backend", {})
+    remote_state_backend = lookup(local.config, "remote_state_backend", {})
   }
 
   backend = local.backend_configs[local.backend_config_key]
 
-  workspace            = local.config.workspace
+  workspace            = lookup(local.config, "workspace", "")
   workspace_key_prefix = lookup(local.backend, "workspace_key_prefix", null)
 
-  remote_state_enabled = ! var.bypass
+  remote_state_enabled = !var.bypass
 
   remote_states = {
     s3     = data.terraform_remote_state.s3

--- a/modules/remote-state/variables.tf
+++ b/modules/remote-state/variables.tf
@@ -32,3 +32,9 @@ variable "bypass" {
   description = "Set to true to skip looking up the remote state and just return the defaults"
   default     = false
 }
+
+variable "ignore_errors" {
+  type        = bool
+  description = "Set to true to ignore errors from the 'utils' provider (if the component is not found in the stack)"
+  default     = false
+}

--- a/modules/remote-state/versions.tf
+++ b/modules/remote-state/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.7"
+      version = ">= 0.17.15"
     }
   }
 }

--- a/modules/settings/versions.tf
+++ b/modules/settings/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.7"
+      version = ">= 0.17.15"
     }
   }
 }

--- a/modules/spacelift/versions.tf
+++ b/modules/spacelift/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.7"
+      version = ">= 0.17.15"
     }
   }
 }

--- a/modules/vars/versions.tf
+++ b/modules/vars/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.7"
+      version = ">= 0.17.15"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.7"
+      version = ">= 0.17.15"
     }
   }
 }


### PR DESCRIPTION
## what
* Update `utils` provider
* Add `ignore_errors` variable to `remote-state`
* Update GitHub workflows

## why
* Use latest `utils` provider (which uses latest code from `atmos` with new features and bug fixes)
* `utils` provider is used to read remote state of components. Sometimes we want to ignore errors if a component does not exist in a stack. If `ignore_errors = false`, the `utils` provider could throw an error: Could not find config for the component 'xxxx' in the stack 'yyy'. Note that terraform `try()` does not catch errors from providers, so `try(module.remote_state.outputs, {})` will not work and will still crash the process. Setting `ignore_errors = true` solves this.

## references
* https://github.com/cloudposse/terraform-provider-utils/pull/105
* https://github.com/cloudposse/atmos/pull/120
