### PR TITLE
[remote-state] bugfix: Handle case where defaults is incompatible type

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,9 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
+  "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
     "ignorePaths": ["**/context.tf", "examples/**"]
   }
 }
-

--- a/examples/remote-state/main.tf
+++ b/examples/remote-state/main.tf
@@ -4,6 +4,13 @@ module "remote_state_using_stack" {
   component = "test/test-component-override"
   stack     = "tenant1-ue2-dev"
 
+  # Verify that a default output not matching the real output does not cause a Terraform error
+  defaults = {
+    val1 = ["default-list"]
+    val2 = "default-value"
+  }
+
+
   context = module.this.context
 }
 

--- a/modules/remote-state/main.tf
+++ b/modules/remote-state/main.tf
@@ -36,6 +36,8 @@ locals {
     static = [{ outputs = local.backend }]
   }
 
-  remote_state_backend_key = var.bypass ? "bypass" : local.backend_type
-  outputs                  = try(length(local.remote_state_backend_key), 0) > 0 ? local.remote_states[local.remote_state_backend_key][0].outputs : var.defaults
+  remote_state_backend_key          = var.bypass ? "bypass" : local.backend_type
+  computed_remote_state_backend_key = try(length(local.remote_states[local.remote_state_backend_key]), 0) > 0 ? local.remote_state_backend_key : "bypass"
+
+  outputs = local.remote_states[local.computed_remote_state_backend_key][0].outputs
 }


### PR DESCRIPTION
## what
- [remote-state] bugfix: Handle case where `defaults` is a Terraform type incompatible with the actual remote state outputs, leading Terraform to complain:
```shell
Error: Inconsistent conditional result types

The true and false result expressions must have consistent types. The given expressions are object and object, respectively.
```

## why
- bug fix

