### PR TITLE
Add ENV vars to `utils` provider. Update `utils` provider versions

### DIFF
--- a/examples/backend/main.tf
+++ b/examples/backend/main.tf
@@ -4,6 +4,7 @@ module "backend" {
   stack         = var.stack
   component     = var.component
   ignore_errors = var.ignore_errors
+  env           = var.env
 
   context = module.this.context
 }

--- a/examples/backend/variables.tf
+++ b/examples/backend/variables.tf
@@ -14,3 +14,9 @@ variable "ignore_errors" {
   description = "Set to true to ignore errors from the 'utils' provider (if the component is not found in the stack)"
   default     = false
 }
+
+variable "env" {
+  type        = map(string)
+  description = "Map of ENV vars in the format `key=value`. These ENV vars will be set in the `utils` provider before executing the data source"
+  default     = null
+}

--- a/examples/backend/versions.tf
+++ b/examples/backend/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.24"
+      version = ">= 0.17.26"
     }
   }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.24"
+      version = ">= 0.17.26"
     }
   }
 }

--- a/examples/remote-state/main.tf
+++ b/examples/remote-state/main.tf
@@ -10,6 +10,9 @@ module "remote_state_using_stack" {
     val2 = "default-value"
   }
 
+  env = {
+    ATMOS_CLI_CONFIG_PATH = path.module
+  }
 
   context = module.this.context
 }
@@ -21,6 +24,10 @@ module "remote_state_using_context" {
   tenant      = "tenant1"
   environment = "ue2"
   stage       = "dev"
+
+  env = {
+    ATMOS_CLI_CONFIG_PATH = path.module
+  }
 
   context = module.this.context
 }
@@ -39,6 +46,10 @@ module "remote_state_using_context_ignore_errors" {
 
   defaults = {
     default_output = "default-value"
+  }
+
+  env = {
+    ATMOS_CLI_CONFIG_PATH = path.module
   }
 
   context = module.this.context

--- a/examples/remote-state/versions.tf
+++ b/examples/remote-state/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.24"
+      version = ">= 0.17.26"
     }
   }
 }

--- a/examples/spacelift/main.tf
+++ b/examples/spacelift/main.tf
@@ -6,5 +6,7 @@ module "spacelift" {
   component_deps_processing_enabled = var.component_deps_processing_enabled
   imports_processing_enabled        = var.imports_processing_enabled
 
+  env = var.env
+
   context = module.this.context
 }

--- a/examples/spacelift/variables.tf
+++ b/examples/spacelift/variables.tf
@@ -21,3 +21,9 @@ variable "stack_config_path_template" {
   description = "Stack config path template"
   default     = "stacks/%s.yaml"
 }
+
+variable "env" {
+  type        = map(string)
+  description = "Map of ENV vars in the format `key=value`. These ENV vars will be set in the `utils` provider before executing the data source"
+  default     = null
+}

--- a/examples/spacelift/versions.tf
+++ b/examples/spacelift/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.24"
+      version = ">= 0.17.26"
     }
   }
 }

--- a/examples/stack/versions.tf
+++ b/examples/stack/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.24"
+      version = ">= 0.17.26"
     }
   }
 }

--- a/examples/stacks/versions.tf
+++ b/examples/stacks/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.24"
+      version = ">= 0.17.26"
     }
   }
 }

--- a/modules/backend/main.tf
+++ b/modules/backend/main.tf
@@ -5,6 +5,7 @@ data "utils_component_config" "config" {
   environment   = module.always.environment
   stage         = module.always.stage
   ignore_errors = var.ignore_errors
+  env           = var.env
 }
 
 locals {

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -14,3 +14,9 @@ variable "ignore_errors" {
   description = "Set to true to ignore errors from the 'utils' provider (if the component is not found in the stack)"
   default     = false
 }
+
+variable "env" {
+  type        = map(string)
+  description = "Map of ENV vars in the format `key=value`. These ENV vars will be set in the `utils` provider before executing the data source"
+  default     = null
+}

--- a/modules/backend/versions.tf
+++ b/modules/backend/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.24"
+      version = ">= 0.17.26"
     }
   }
 }

--- a/modules/env/versions.tf
+++ b/modules/env/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.24"
+      version = ">= 0.17.26"
     }
   }
 }

--- a/modules/remote-state/main.tf
+++ b/modules/remote-state/main.tf
@@ -5,6 +5,7 @@ data "utils_component_config" "config" {
   environment   = module.always.environment
   stage         = module.always.stage
   ignore_errors = var.ignore_errors
+  env           = var.env
 }
 
 locals {
@@ -27,7 +28,7 @@ locals {
   workspace            = lookup(local.config, "workspace", "")
   workspace_key_prefix = lookup(local.backend, "workspace_key_prefix", null)
 
-  remote_state_enabled = ! var.bypass
+  remote_state_enabled = !var.bypass
 
   remote_states = {
     s3     = data.terraform_remote_state.s3

--- a/modules/remote-state/main.tf
+++ b/modules/remote-state/main.tf
@@ -28,7 +28,7 @@ locals {
   workspace            = lookup(local.config, "workspace", "")
   workspace_key_prefix = lookup(local.backend, "workspace_key_prefix", null)
 
-  remote_state_enabled = !var.bypass
+  remote_state_enabled = ! var.bypass
 
   remote_states = {
     s3     = data.terraform_remote_state.s3

--- a/modules/remote-state/variables.tf
+++ b/modules/remote-state/variables.tf
@@ -38,3 +38,9 @@ variable "ignore_errors" {
   description = "Set to true to ignore errors from the 'utils' provider (if the component is not found in the stack)"
   default     = false
 }
+
+variable "env" {
+  type        = map(string)
+  description = "Map of ENV vars in the format `key=value`. These ENV vars will be set in the `utils` provider before executing the data source"
+  default     = null
+}

--- a/modules/remote-state/versions.tf
+++ b/modules/remote-state/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.24"
+      version = ">= 0.17.26"
     }
   }
 }

--- a/modules/settings/versions.tf
+++ b/modules/settings/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.24"
+      version = ">= 0.17.26"
     }
   }
 }

--- a/modules/spacelift/main.tf
+++ b/modules/spacelift/main.tf
@@ -3,6 +3,7 @@ data "utils_spacelift_stack_config" "spacelift_stacks" {
   process_component_deps     = var.component_deps_processing_enabled
   process_imports            = var.imports_processing_enabled
   stack_config_path_template = var.stack_config_path_template
+  env                        = var.env
 }
 
 locals {

--- a/modules/spacelift/variables.tf
+++ b/modules/spacelift/variables.tf
@@ -21,3 +21,9 @@ variable "stack_config_path_template" {
   description = "Stack config path template"
   default     = "stacks/%s.yaml"
 }
+
+variable "env" {
+  type        = map(string)
+  description = "Map of ENV vars in the format `key=value`. These ENV vars will be set in the `utils` provider before executing the data source"
+  default     = null
+}

--- a/modules/spacelift/versions.tf
+++ b/modules/spacelift/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.24"
+      version = ">= 0.17.26"
     }
   }
 }

--- a/modules/vars/versions.tf
+++ b/modules/vars/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.17.24"
+      version = ">= 0.17.26"
     }
   }
 }


### PR DESCRIPTION
## what
* Add ENV vars to `utils` provider
* Update `utils` provider versions

## why
* Allow controlling the execution of `atmos`, `utils` provider and terraform modules using ENV vars

```hcl
module "remote_state" {
  source = "../../modules/remote-state"

  component = "test/test-component-override"
  stack     = "tenant1-ue2-dev"

  env = {
    ATMOS_CLI_CONFIG_PATH = path.module
  }

  context = module.this.context
}
```

* In particular, the latest `atmos` and `utils` provider versions support `ATMOS_CLI_CONFIG_PATH` ENV var to set the path to `atmos.yaml` CLI config file. This ENV var will allow using the `monorepo` pattern by loading a remote repo and pointing to its `atmos.yaml` using `ATMOS_CLI_CONFIG_PATH` ENV var

``` hcl
module "monorepo" {
  source = "git::ssh://git@github.com/ACME/infrastructure.git?ref=v0.0.1"
}

locals {
  monorepo_local_path = "${path.module}/.terraform/modules/monorepo"
}

module "iam_roles" {
  source  = "git::ssh://git@github.com/ACME/infrastructure.git//components/terraform/account-map/modules/iam-roles?ref=v0.0.1"
  
  env = {
     ATMOS_CLI_CONFIG_PATH = "${path.module}/.terraform/modules/monorepo/rootfs/usr/local/etc/atmos"
  } 
  
  depends_on = [module.monorepo]
}
```

## references
* https://github.com/cloudposse/terraform-provider-utils/pull/174

