### PR TITLE
Updating utils pin version to 1.5.0 in remote-state module

### DIFF
--- a/modules/remote-state/versions.tf
+++ b/modules/remote-state/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 1.3.0"
+      version = ">= 1.5.0"
     }
   }
 }


### PR DESCRIPTION
## what & why?

* Bumping utils version in remote-state module to take advantage of recent updates
