### PR TITLE
Allow cloudposse/utils provider v1.8.0

### DIFF
--- a/examples/remote-state/versions.tf
+++ b/examples/remote-state/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 1.7.1"
+      version = ">= 1.8.0"
     }
   }
 }

--- a/modules/remote-state/versions.tf
+++ b/modules/remote-state/versions.tf
@@ -21,7 +21,7 @@ terraform {
       # add a != constraint for that version.
       # Leave a redundant != constraint for the last known bad version
       # as an example of how to add a constraint for a bad version.
-      version = ">= 1.7.1, != 1.4.0, <= 1.7.1"
+      version = ">= 1.7.1, != 1.4.0, <= 1.8.0"
     }
   }
 }


### PR DESCRIPTION
## what
* Allow `remote-state` module to use `cloudposse/utils` provider v1.8.0

## why
* Enable interoperation with modules requiring new features in provider v1.8.0

## references

- https://github.com/cloudposse/terraform-provider-utils/pull/281
