### PR TITLE
update version pinning of cloudposse/utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,6 @@ We highly recommend that in your code you pin the version to the exact version y
 using so that your infrastructure remains stable, and update versions in a
 systematic way so that they do not catch you by surprise.
 
-Also, because of a bug in the Terraform registry ([hashicorp/terraform#21417](https://github.com/hashicorp/terraform/issues/21417)),
-the registry shows many of our inputs as required when in fact they are optional.
-The table below correctly indicates which inputs are required.
-
 
 For a complete example, see [examples/complete](examples/complete).
 

--- a/modules/remote-state/versions.tf
+++ b/modules/remote-state/versions.tf
@@ -12,16 +12,10 @@ terraform {
     }
     utils = {
       source = "cloudposse/utils"
-      # Do not allow automatic updates to this provider
-      # until we have tested the new version thoroughly.
-      # Move the <= version constraint to the latest version
-      # after testing is complete. Move the >= version constraint
-      # when a new version adds a required feature or fixes a bug.
-      # If a version in between is found to have a bug,
-      # add a != constraint for that version.
-      # Leave a redundant != constraint for the last known bad version
-      # as an example of how to add a constraint for a bad version.
-      version = ">= 1.7.1, != 1.4.0, <= 1.8.0"
+      # We were previously pinning this to <=1.8.0, but changing this each time we had a new version was a pain. As
+      # a compromise, we'll pin to a minimum version, but allow any patch version below 2.0.0 and we will make sure
+      # that if we make any major/breaking changes in cloudposse/utils, we'll increment to 2.0.0.
+      version = ">= 1.7.1, != 1.4.0, < 2.0.0"
     }
   }
 }


### PR DESCRIPTION
## what

Update the pinning of upstream `cloudposse/utils` to `<2.0.0`

## why

We previously added this pinning because we mistakenly released some changes to the provider without testing backward compatibility and left customers in a broken state. In future releases of `cloudposse/utils` we will release any potential breaking changes as `2.0.0`. Pinning to `<2.0.0` will allow us to continue to take advantage of bug fixes in the `1.x.x` versions and allow the caller to specify a pinned version in their root module if desired.
