### PR TITLE
feat(remote-state): enable assume_role block in backend configuration to fix deprecation warning

### DIFF
--- a/modules/remote-state/data-source.tf
+++ b/modules/remote-state/data-source.tf
@@ -68,6 +68,8 @@ locals {
       # Use the role to access the remote state if the component is not privileged and `role_arn` is specified
       role_arn = !coalesce(try(local.backend.privileged, null), var.privileged) && contains(keys(local.backend), "role_arn") ? local.backend.role_arn : null
 
+      assume_role = local.backend.assume_role
+
       # Use the profile to access the remote state if the component is not privileged and `profile` is specified
       profile = !coalesce(try(local.backend.privileged, null), var.privileged) && contains(keys(local.backend), "profile") ? local.backend.profile : null
 


### PR DESCRIPTION
## what

Solves a deprecation warning for using `role_arn` parameter instead of `assume_role` configuration block.
Doesn't use the complicated negation-of-try-contains ternary logic.. but it seems to work whether the value is present or not, being backwards compatible and not erroring if people don't have assume_role blocks in their configuration. Please test because you guys are more familiar with the usage of this module than I am.

## why

I was receiving this deprecation warning and wanted to silence it.

## references

https://developer.hashicorp.com/terraform/language/settings/backends/s3#role_arn-1
