### PR TITLE
fix(data-source.tf): address deprecation warning

### DIFF
--- a/modules/remote-state/data-source.tf
+++ b/modules/remote-state/data-source.tf
@@ -66,7 +66,9 @@ locals {
       # component, we don't touch the `globals.yaml` file at all, and we don't update the component's `role_arn` and `profile` settings).
 
       # Use the role to access the remote state if the component is not privileged and `role_arn` is specified
-      role_arn = !coalesce(try(local.backend.privileged, null), var.privileged) && contains(keys(local.backend), "role_arn") ? local.backend.role_arn : null
+      assume_role = {
+        role_arn = !coalesce(try(local.backend.privileged, null), var.privileged) && contains(keys(local.backend), "role_arn") ? local.backend.role_arn : null
+      }
 
       # Use the profile to access the remote state if the component is not privileged and `profile` is specified
       profile = !coalesce(try(local.backend.privileged, null), var.privileged) && contains(keys(local.backend), "profile") ? local.backend.profile : null


### PR DESCRIPTION
## what

changes 

role_arn -> assume_role.role_arn

## why

addresses deprecated parameter warning
```
Warning: Deprecated Parameters

  with module.xxx.data.terraform_remote_state.data_source[0],
  on ../terraform-yaml-stack-config/modules/remote-state/data-source.tf line 88, in data "terraform_remote_state" "data_source":
  88: data "terraform_remote_state" "data_source" {

The following parameters have been deprecated. Replace them as follows:
  * role_arn -> assume_role.role_arn


(and 3 more similar warnings elsewhere

```