### PR TITLE
Update .github/settings.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -7,3 +7,4 @@ repository:
   topics: yaml, configuration, config, configuration-management, terraform, terraform-module, helm, helmfile, configuration-files, configs, yaml-configuration, stack, stacks
 
 
+


### PR DESCRIPTION
## what
- Update `.github/settings.yml` 
- Drop `.github/auto-release.yml` files

## why
- Re-apply `.github/settings.yml` from org level
- Use organization level auto-release settings

## references
- DEV-1242 Add protected tags with Repository Rulesets on GitHub
