### PR TITLE
Update cloudposse/utils provider to v2.0.0

### DIFF
--- a/examples/backend/versions.tf
+++ b/examples/backend/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 1.8.0"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/examples/backend/versions.tf
+++ b/examples/backend/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 2.0.0"
+      version = ">= 2.0.0, < 3.0.0"
     }
   }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 1.8.0"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 2.0.0"
+      version = ">= 2.0.0, < 3.0.0"
     }
   }
 }

--- a/examples/remote-state/versions.tf
+++ b/examples/remote-state/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 1.8.0"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/examples/remote-state/versions.tf
+++ b/examples/remote-state/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 2.0.0"
+      version = ">= 2.0.0, < 3.0.0"
     }
   }
 }

--- a/examples/spacelift/versions.tf
+++ b/examples/spacelift/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 1.8.0"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/examples/spacelift/versions.tf
+++ b/examples/spacelift/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 2.0.0"
+      version = ">= 2.0.0, < 3.0.0"
     }
   }
 }

--- a/examples/stack/versions.tf
+++ b/examples/stack/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 1.8.0"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/examples/stack/versions.tf
+++ b/examples/stack/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 2.0.0"
+      version = ">= 2.0.0, < 3.0.0"
     }
   }
 }

--- a/examples/stacks/versions.tf
+++ b/examples/stacks/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 1.8.0"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/examples/stacks/versions.tf
+++ b/examples/stacks/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 2.0.0"
+      version = ">= 2.0.0, < 3.0.0"
     }
   }
 }

--- a/modules/backend/versions.tf
+++ b/modules/backend/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 1.7.1"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/modules/backend/versions.tf
+++ b/modules/backend/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 2.0.0"
+      version = ">= 2.0.0, < 3.0.0"
     }
   }
 }

--- a/modules/env/versions.tf
+++ b/modules/env/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 1.7.1"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/modules/env/versions.tf
+++ b/modules/env/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 2.0.0"
+      version = ">= 2.0.0, < 3.0.0"
     }
   }
 }

--- a/modules/remote-state/versions.tf
+++ b/modules/remote-state/versions.tf
@@ -11,11 +11,8 @@ terraform {
       version = ">= 2.0"
     }
     utils = {
-      source = "cloudposse/utils"
-      # We were previously pinning this to <=1.8.0, but changing this each time we had a new version was a pain. As
-      # a compromise, we'll pin to a minimum version, but allow any patch version below 2.0.0 and we will make sure
-      # that if we make any major/breaking changes in cloudposse/utils, we'll increment to 2.0.0.
-      version = ">= 1.7.1, < 2.0.0"
+      source  = "cloudposse/utils"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/modules/remote-state/versions.tf
+++ b/modules/remote-state/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 2.0.0"
+      version = ">= 2.0.0, < 3.0.0"
     }
   }
 }

--- a/modules/settings/versions.tf
+++ b/modules/settings/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 1.7.1"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/modules/settings/versions.tf
+++ b/modules/settings/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 2.0.0"
+      version = ">= 2.0.0, < 3.0.0"
     }
   }
 }

--- a/modules/spacelift/versions.tf
+++ b/modules/spacelift/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 1.7.1"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/modules/spacelift/versions.tf
+++ b/modules/spacelift/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 2.0.0"
+      version = ">= 2.0.0, < 3.0.0"
     }
   }
 }

--- a/modules/vars/versions.tf
+++ b/modules/vars/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 1.7.1"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/modules/vars/versions.tf
+++ b/modules/vars/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 2.0.0"
+      version = ">= 2.0.0, < 3.0.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 1.7.1"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 2.0.0"
+      version = ">= 2.0.0, < 3.0.0"
     }
   }
 }


### PR DESCRIPTION
## what

- Update `cloudposse/utils` provider version constraint to `>= 2.0.0, < 3.0.0` across all 13 `versions.tf` files (root module, 6 child modules, 6 examples)
- Remove the old `< 2.0.0` upper bound from `modules/remote-state` that was blocking the v2 upgrade
- Apply the `< 3.0.0` upper bound consistently across all modules (previously only `modules/remote-state` had an upper bound)

## why

- The `cloudposse/utils` provider v1.x embeds Atmos v1.189.0, which panics when it encounters newer `atmos.yaml` features (`stores`, `hooks`, `templates.settings.gomplate`, `!terraform.state` YAML tags). This causes a critical **"Plugin did not respond"** crash in `data "utils_component_config"`, blocking all components that use the `remote-state` module (56+ components in a typical infrastructure repo)
- Provider v2.0.0 upgrades the embedded Atmos from v1.189.0 to v1.207.0, which can parse all current `atmos.yaml` features without crashing
- The `< 3.0.0` upper bound is applied consistently to all modules and examples to guard against future breaking changes in the provider, following the same pattern previously used only in `modules/remote-state`
- This is a **major** version bump because users on older Atmos CLI versions (< 1.200) were unaffected by the crash and may need to verify compatibility after upgrading

## references

- [`cloudposse/utils` provider v2.0.0 release](https://github.com/cloudposse/terraform-provider-utils/releases/tag/v2.0.0)
- [Provider PR #522](https://github.com/cloudposse/terraform-provider-utils/pull/522) — full root cause analysis, API migration details, and 19 new tests
- [Root cause analysis doc](https://github.com/cloudposse/terraform-provider-utils/blob/main/docs/fixes/2026-02-19-atmos-version-mismatch-plugin-crash.md) — call chain, scope of impact, and fix details